### PR TITLE
Filter embedding models using Bedrock API instead of hardcoded patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,13 +133,9 @@ The extension automatically filters and displays only models that:
 
 ### Models Automatically Excluded
 
-The following models are filtered out as they don't support the Converse API tool use feature:
+The extension automatically filters models to show only text generation models (using `byOutputModality: "TEXT"` in the Bedrock API). This excludes embedding models and image generation models.
 
-- Amazon Titan Text (legacy models)
-- Stability AI models (image generation only)
-- AI21 Jurassic 2
-- Meta Llama 2 and Llama 3.0
-- All embedding models (Titan Embed, Cohere Embed)
+**Note**: Some text models that appear in the list may have limited or no tool calling support (e.g., legacy Amazon Titan Text, AI21 Jurassic 2, Meta Llama 2 and 3.0). These will fail gracefully if tool calls are attempted.
 
 ## Troubleshooting
 

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -126,7 +126,9 @@ export class BedrockAPIClient {
 
   async fetchModels(abortSignal?: AbortSignal): Promise<BedrockModelSummary[]> {
     try {
-      const command = new ListFoundationModelsCommand({});
+      const command = new ListFoundationModelsCommand({
+        byOutputModality: "TEXT",
+      });
       const response = await this.bedrockClient.send(command, { abortSignal });
 
       return (response.modelSummaries ?? []).map((summary) => ({

--- a/src/test/bedrock-client.integration.test.ts
+++ b/src/test/bedrock-client.integration.test.ts
@@ -82,6 +82,39 @@ suite("BedrockAPIClient Integration Tests", () => {
       }
     });
 
+    test("should filter out embedding models using byOutputModality: TEXT", async function () {
+      this.timeout(30_000);
+
+      const models = await client.fetchModels();
+
+      // Check for embedding models - these should NOT be present with TEXT filter
+      const embeddingModels = models.filter(
+        (m) =>
+          m.modelId.includes("embed") ||
+          m.outputModalities.includes("EMBEDDING") ||
+          m.modelId.includes("titan-embed") ||
+          m.modelId.includes("cohere.embed"),
+      );
+
+      assert.strictEqual(
+        embeddingModels.length,
+        0,
+        "Should NOT return embedding models when byOutputModality: TEXT filter is applied",
+      );
+
+      // Verify all returned models have TEXT in outputModalities
+      const nonTextModels = models.filter((m) => !m.outputModalities.includes("TEXT"));
+      assert.strictEqual(
+        nonTextModels.length,
+        0,
+        "All returned models should have TEXT in outputModalities",
+      );
+
+      console.log(
+        `✓ Embedding models successfully filtered out (${models.length} text models returned)`,
+      );
+    });
+
     test("should fetch models with custom AWS profile if configured", async function () {
       this.timeout(30_000);
 


### PR DESCRIPTION
## Summary

- Replaced hardcoded `TOOL_INCAPABLE_MODEL_PATTERNS` with API-level filtering using `byOutputModality: "TEXT"`
- Removed manual pattern matching logic for filtering embedding models
- Added test coverage to verify embedding models are properly filtered out
- Updated documentation to reflect the new API-based filtering approach

## Motivation

The previous approach maintained a hardcoded list of regex patterns to exclude embedding models and other tool-incapable models. This was error-prone and required manual updates when new models were added. Since all the excluded embedding models share a common characteristic (they have `EMBEDDING` as output modality, not `TEXT`), we can use the Bedrock API's native filtering capability.

## Changes

### Code Changes
- **src/bedrock-client.ts**: Added `byOutputModality: "TEXT"` parameter to `ListFoundationModelsCommand`
- **src/provider.ts**: Removed `TOOL_INCAPABLE_MODEL_PATTERNS` constant, `isToolIncapableModel()` function, and the filtering logic that used it
- **src/test/bedrock-client.integration.test.ts**: Added test to verify embedding models are filtered out and all returned models have TEXT output modality

### Documentation Changes
- **README.md**: Updated "Models Automatically Excluded" section to explain API-based filtering and added a note about text models with limited tool support

## Test Results

All 32 tests pass. The new test confirms:
- ✅ Zero embedding models returned (was >28 before)
- ✅ All returned models have TEXT in outputModalities
- ✅ 71 text models returned in us-east-1 (vs 99 total models before filtering)

## Benefits

1. **Maintainability**: No need to update hardcoded patterns when new embedding models are added
2. **Correctness**: Uses AWS's official model classification rather than pattern matching
3. **Performance**: Filtering happens at the API level, reducing data transfer
4. **Simplicity**: Reduces code complexity (-63 lines, +38 lines)

## Test plan

- [x] Run `bun run test` - all tests pass
- [x] Run `bunx tsgo --noEmit` - no TypeScript errors
- [x] Run `bunx eslint` - no linting errors
- [x] Verify embedding models are filtered out via test
- [x] Verify all returned models have TEXT output modality

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Model filtering now displays only text-generation models, automatically excluding embedding and image-generation models.

* **Documentation**
  * Updated documentation to clarify model filtering criteria and note that some text models may have limited or no tool calling support, with graceful failure handling.

* **Tests**
  * Added integration tests to verify embedding model filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->