### PR TITLE
Use configured profile/access keys for SSM region fetch

### DIFF
--- a/.github/pr-ssm-creds-body.md
+++ b/.github/pr-ssm-creds-body.md
@@ -1,0 +1,25 @@
+This PR fixes region selection failing with "Could not load credentials from any providers" when a user has set non-default auth.
+
+Changes
+
+- Reuse previously provided credentials (profile or access keys) to call SSM when fetching Bedrock regions
+- Fallback to the default credential provider chain if none are configured
+- Thread credentials into the region selection flow
+
+Details
+
+- `getBedrockRegionsFromSSM` optionally accepts `{ globalState, secrets }` and resolves credentials
+- `resolveSsmCredentials` prioritizes:
+  1. Selected method: Access Keys, then Profile
+  2. Any stored Access Keys or Profile
+  3. Default provider chain
+- Still queries SSM in `us-east-1`
+- If SSM still can’t be called, we gracefully prompt for manual region
+
+Testing
+
+- Set auth method to **Profile** and choose a profile → Region list loads
+- Set auth method to **Access Keys** with valid keys → Region list loads
+- With only **API Key** configured and no other creds → Manual prompt appears
+
+No API surface changes beyond optional parameters; existing callers continue to work.

--- a/src/commands/manage-settings.ts
+++ b/src/commands/manage-settings.ts
@@ -1,6 +1,6 @@
 import { paginateGetParametersByPath, SSMClient } from "@aws-sdk/client-ssm";
 import { fromIni } from "@aws-sdk/credential-providers";
-import type { AwsCredentialIdentity } from "@aws-sdk/types";
+import type { AwsCredentialIdentity, AwsCredentialIdentityProvider } from "@aws-sdk/types";
 import * as nodeNativeFetch from "smithy-node-native-fetch";
 import * as vscode from "vscode";
 
@@ -463,7 +463,7 @@ async function promptForManualRegion(
 async function resolveSsmCredentials(
   globalState?: vscode.Memento,
   secrets?: vscode.SecretStorage,
-): Promise<AwsCredentialIdentity | undefined> {
+): Promise<AwsCredentialIdentity | AwsCredentialIdentityProvider | undefined> {
   try {
     const method = globalState?.get<AuthMethod>("bedrock.authMethod") ?? "profile";
 
@@ -507,7 +507,7 @@ async function resolveSsmCredentials(
         // Return a refreshing provider from shared ini
         // Note: SSMClient accepts a provider; typing keeps identity, runtime is fine
         // Cast to any to satisfy union type without extra imports
-        return fromIni({ profile }) as unknown as AwsCredentialIdentity;
+        return fromIni({ profile });
       }
     }
 
@@ -515,7 +515,7 @@ async function resolveSsmCredentials(
     const ak = await readAccessKeys();
     if (ak) return ak;
     const profile = await readProfile();
-    if (profile) return fromIni({ profile }) as unknown as AwsCredentialIdentity;
+    if (profile) return fromIni({ profile });
 
     // 3) Default chain
     return undefined;


### PR DESCRIPTION
This PR fixes region selection failing with "Could not load credentials from any providers" when a user has set non-default auth.

Changes
- Reuse previously provided credentials (profile or access keys) to call SSM when fetching Bedrock regions
- Fallback to the default credential provider chain if none are configured
- Thread credentials into the region selection flow

Details
- `getBedrockRegionsFromSSM` optionally accepts `{ globalState, secrets }` and resolves credentials
- `resolveSsmCredentials` prioritizes:
  1) Selected method: Access Keys, then Profile
  2) Any stored Access Keys or Profile
  3) Default provider chain
- Still queries SSM in `us-east-1`
- If SSM still can’t be called, we gracefully prompt for manual region

Testing
- Set auth method to **Profile** and choose a profile → Region list loads
- Set auth method to **Access Keys** with valid keys → Region list loads
- With only **API Key** configured and no other creds → Manual prompt appears

No API surface changes beyond optional parameters; existing callers continue to work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Region selection now respects configured AWS auth methods (access keys or profile) and uses stored credentials when available.
  * Region retrieval will fall back to the default AWS provider chain if no explicit credentials are configured.

* **Bug Fixes**
  * Region list loading works correctly when non-default authentication is set; if automated lookup fails, users are prompted to enter a region manually.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->