### PR TITLE
feat: use AWS SDK native bearer token support for API key auth

### DIFF
--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -500,9 +500,7 @@ export class BedrockAPIClient {
    * @param authConfig Authentication configuration
    * @returns Object with credentials or token provider, or undefined for default credentials
    */
-  private getCredentialsOrToken(
-    authConfig: AuthConfig,
-  ):
+  private getCredentialsOrToken(authConfig: AuthConfig):
     | undefined
     | {
         credentials?: AwsCredentialIdentity | AwsCredentialIdentityProvider;


### PR DESCRIPTION
## Summary

Replace `process.env.AWS_BEARER_TOKEN_BEDROCK` with AWS SDK v3's native token configuration option for better security and compliance with AWS SDK best practices.

## Changes

- Added `TokenIdentityProvider` from `@smithy/types` for proper token handling
- Replaced `getCredentials()` method with `getCredentialsOrToken()` to support both credentials and token providers
- Implemented token provider for `api-key` authentication method using AWS SDK's native `token` option
- Removed all `process.env.AWS_BEARER_TOKEN_BEDROCK` environment variable operations

## Benefits

- **More secure**: Eliminates sensitive token storage in environment variables
- **Better architecture**: Uses AWS SDK's native bearer token support (available since v3.844.0)
- **Type-safe**: Proper TypeScript types for token providers
- **Cleaner code**: No manual environment variable management required

## Testing

- Type checking passes: `bunx tsgo --noEmit`
- ESLint passes: `bunx eslint --fix src/bedrock-client.ts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added token-based authentication as an alternative to profile and access-key methods.
  * API key auth now uses a token provider instead of modifying environment variables.

* **Improvements**
  * Streamlined authentication flow and client initialization with better handling for credentials or tokens.
  * Improved caching behavior and automatic clearing of profile cache on reconfiguration.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->