### PR TITLE
fix: prevent model selection reset on VS Code restart

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -34,6 +34,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
   private chatEndpoints: { model: string; modelMaxPromptTokens: number }[] = [];
   private readonly client: BedrockAPIClient;
+  /** Tracks whether the initial model fetch has completed (for avoiding startup feedback loops) */
+  private initialFetchComplete = false;
   private lastThinkingBlock?: ThinkingBlock;
   private readonly streamProcessor: StreamProcessor;
 
@@ -55,6 +57,14 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     } catch {
       // ignore
     }
+  }
+
+  /**
+   * Returns true if the initial model fetch has completed.
+   * Used to avoid feedback loops when responding to onDidChangeChatModels during startup.
+   */
+  public isInitialFetchComplete(): boolean {
+    return this.initialFetchComplete;
   }
 
   /**
@@ -321,6 +331,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             model: info.id,
             modelMaxPromptTokens: info.maxInputTokens + info.maxOutputTokens,
           }));
+
+          // Mark initial fetch as complete to allow onDidChangeChatModels handling
+          this.initialFetchComplete = true;
 
           return infos;
         };


### PR DESCRIPTION
## Problem

After VS Code restart, previously selected Bedrock models were being reset/lost. This regression was introduced in v0.5.0 with the inference profile accessibility checking in #79.

## Root Cause

The `onDidChangeChatModels` event was causing a feedback loop during startup:

1. Extension activates and provider returns models
2. VS Code fires `onDidChangeChatModels` (because the model list changed)
3. Extension responds by refreshing the model list
4. Model IDs may differ due to profile accessibility tests (e.g., `global.xxx` vs `us.xxx` vs `anthropic.xxx`)
5. VS Code sees different model IDs and loses track of the user's previous selection
6. Repeat from step 2

## Solution

Added an `isInitialFetchComplete()` flag to the provider that tracks when the first model fetch completes. The extension now:

1. **Skips** `onDidChangeChatModels` events until the initial fetch is complete (avoiding the startup feedback loop)
2. **Responds** to subsequent events (user-initiated model selection/deselection in the quick pick)
3. **Debounces** the handler (500ms) to coalesce rapid changes

This is more robust than a time-based delay because it's based on the actual state of the provider.

## Changes

- `src/provider.ts`:
  - Added `initialFetchComplete` boolean flag
  - Added `isInitialFetchComplete()` public method
  - Set `initialFetchComplete = true` after the first successful model fetch

- `src/extension.ts`:
  - Updated `onDidChangeChatModels` handler to check `provider.isInitialFetchComplete()`
  - Added debouncing (500ms) to coalesce rapid changes
  - Added proper cleanup disposable for the debounce timer
  - Added debug logging for skipped events

## Testing

1. Select some Bedrock models in the model picker
2. Restart VS Code
3. Verify the previously selected models are still selected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed potential startup issues with model initialization
  * Reduced refresh frequency when models change rapidly

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->