### PR TITLE
feat: support GitHub Copilot's anthropic thinking settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A VSCode extension that brings Amazon Bedrock models into GitHub Copilot Chat us
 - **Streaming Support**: Real-time streaming responses for faster feedback
 - **Function Calling**: Full support for tool/function calling capabilities
 - **Cross-Region Inference**: Automatic support for cross-region inference profiles
-- **Extended Thinking**: Automatic support for extended thinking in Claude Opus 4+, Sonnet 4+, and Sonnet 3.7 for enhanced reasoning on complex tasks
+- **Extended Thinking**: Automatic support for extended thinking in Claude Opus 4+, Sonnet 4+, and Sonnet 3.7 for enhanced reasoning on complex tasks. Also respects GitHub Copilot's `github.copilot.chat.anthropic.thinking.enabled` and `github.copilot.chat.anthropic.thinking.maxTokens` settings
 - **1M Context Window**: Optional 1M token context window for Claude Sonnet 4.x models (can be disabled in settings to reduce costs)
 - **Prompt Caching**: Automatic caching of system prompts, tool definitions, and conversation history for faster responses and reduced costs (Claude and Nova models)
 - **Vision Support**: Work with models that support image inputs

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,9 @@ export function activate(context: vscode.ExtensionContext) {
       e.affectsConfiguration("bedrock.context1M.enabled") ||
       e.affectsConfiguration("bedrock.promptCaching.enabled") ||
       e.affectsConfiguration("bedrock.thinking.enabled") ||
-      e.affectsConfiguration("bedrock.thinking.budgetTokens")
+      e.affectsConfiguration("bedrock.thinking.budgetTokens") ||
+      e.affectsConfiguration("github.copilot.chat.anthropic.thinking.enabled") ||
+      e.affectsConfiguration("github.copilot.chat.anthropic.thinking.maxTokens")
     ) {
       provider.notifyModelInformationChanged("configuration changed");
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -78,8 +78,14 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
   const promptCachingEnabled = config.get<boolean>("promptCaching.enabled") ?? true;
 
   // Read thinking settings with defaults
-  const thinkingEnabled = config.get<boolean>("thinking.enabled") ?? true;
-  const thinkingBudgetTokens = config.get<number>("thinking.budgetTokens") ?? 10_000;
+  // Check GitHub Copilot's anthropic thinking settings first, then fall back to bedrock settings
+  const copilotConfig = vscode.workspace.getConfiguration("github.copilot.chat.anthropic");
+  const copilotThinkingEnabled = copilotConfig.get<boolean>("thinking.enabled");
+  const copilotThinkingMaxTokens = copilotConfig.get<number>("thinking.maxTokens");
+
+  const thinkingEnabled = copilotThinkingEnabled ?? config.get<boolean>("thinking.enabled") ?? true;
+  const thinkingBudgetTokens =
+    copilotThinkingMaxTokens ?? config.get<number>("thinking.budgetTokens") ?? 10_000;
 
   return {
     context1M: {


### PR DESCRIPTION
Adds support for reading GitHub Copilot's anthropic thinking settings:

- `github.copilot.chat.anthropic.thinking.enabled`
- `github.copilot.chat.anthropic.thinking.maxTokens`

These settings take priority over the extension's own `bedrock.thinking.*` settings when configured, allowing users who already have these Copilot settings to have them automatically respected.

Priority order:
1. GitHub Copilot settings (if set)
2. Bedrock settings (if set)  
3. Defaults (enabled: true, budgetTokens: 10,000)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that Extended Thinking now respects GitHub Copilot’s thinking configuration when describing behavior.

* **Improvements**
  * Broader detection of changes to thinking-related configuration so updates take effect promptly.
  * Configuration resolution now prefers Copilot thinking settings while falling back to existing defaults.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->