### PR TITLE
Fix inference profile detection and improve model support

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,10 @@
           "scope": "resource"
         },
         "bedrock.reasoningEffort": {
-          "type": "string",
+          "type": [
+            "string",
+            "null"
+          ],
           "default": null,
           "enum": [
             null,

--- a/package.json
+++ b/package.json
@@ -94,6 +94,26 @@
           "description": "Thinking effort level for Claude Opus 4.5 and Sonnet 4.6. Controls how eager Claude is about spending tokens when responding. Higher effort = better quality but more tokens.",
           "scope": "resource"
         },
+        "bedrock.reasoningEffort": {
+          "type": "string",
+          "default": null,
+          "enum": [
+            null,
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ],
+          "enumDescriptions": [
+            "Do not send the reasoning_effort parameter.",
+            "OpenAI gpt-oss only. Fastest, lowest cost. For other models this is treated as 'low'.",
+            "Lowest reasoning budget.",
+            "Balanced reasoning budget.",
+            "Maximum reasoning budget."
+          ],
+          "markdownDescription": "Controls the OpenAI-style `reasoning_effort` additional-model-request field for non-Anthropic models that accept it (currently OpenAI gpt-oss). Leave unset to omit the parameter. Anthropic Claude models are unaffected and continue to use the `bedrock.thinking.*` settings.",
+          "scope": "resource"
+        },
         "bedrock.context1M.enabled": {
           "type": "boolean",
           "default": true,

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -117,7 +117,8 @@ export class BedrockAPIClient {
 
       return response.inputTokens;
     } catch (error) {
-      if (this.isUnsupportedCountTokensError(error, abortSignal)) {
+      const countTokensUnsupported = this.isUnsupportedCountTokensError(error, abortSignal);
+      if (countTokensUnsupported) {
         this.unsupportedCountTokensModels.add(modelId);
         if (baseModelId && baseModelId !== modelId) {
           this.unsupportedCountTokensModels.add(baseModelId);
@@ -141,11 +142,13 @@ export class BedrockAPIClient {
       // The caller should fall back to estimation. Logged at trace level because Copilot
       // Chat calls provideTokenCount many times per turn -- one line per call would
       // flood the output channel.
-      logger.trace(
-        `[Bedrock API Client] CountTokens not available for model ${modelId}: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
-      );
+      if (countTokensUnsupported) {
+        logger.trace(
+          `[Bedrock API Client] CountTokens not available for model ${modelId}: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
       return undefined;
     }
   }
@@ -394,14 +397,14 @@ export class BedrockAPIClient {
 
     // Check if this looks like an inference profile
     // Patterns:
-    // - Regional/Global: starts with a 2-letter AWS region prefix or "global"
-    //   (us., eu., ap., ca., sa., me., af., il., cn., global.)
+    // - Regional/Global: starts with a valid Bedrock cross-region inference
+    //   profile prefix (us., eu., apac., global.)
     //   Restricted to known prefixes so we don't false-positive on vendor IDs
     //   like `zai.glm-5` (zai is 3 letters but is NOT an AWS region prefix).
     // - Application: starts with "ip-" (ip-...)
     // - ARN: full ARN format (arn:aws:bedrock:region:account:inference-profile/...
     //   or application-inference-profile/...)
-    const dotProfilePattern = /^(global|us|eu|ap|ca|sa|me|af|il|cn)\./;
+    const dotProfilePattern = /^(global|us|eu|apac)\./;
     const arnProfilePattern =
       /^arn:aws(-[a-z0-9]+)?:bedrock:[a-z0-9-]+:\d{12}:(application-)?inference-profile\//;
     const appProfileIdPattern = /^ip-[a-z0-9]+/i;

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -117,10 +117,7 @@ export class BedrockAPIClient {
 
       return response.inputTokens;
     } catch (error) {
-      // Don't cache cancellations -- the user just aborted this particular call.
-      const isAbort =
-        error instanceof Error && (error.name === "AbortError" || abortSignal?.aborted);
-      if (!isAbort) {
+      if (this.isUnsupportedCountTokensError(error, abortSignal)) {
         this.unsupportedCountTokensModels.add(modelId);
         if (baseModelId && baseModelId !== modelId) {
           this.unsupportedCountTokensModels.add(baseModelId);
@@ -438,11 +435,11 @@ export class BedrockAPIClient {
 
       return baseModelId;
     } catch (error) {
-      // If GetInferenceProfile fails, assume it's a regular model ID.
-      // Cache the negative result (mapping to itself) so we don't hammer the
-      // API on every token-count call -- Copilot Chat issues many of those
-      // per turn and each round-trip adds noticeable latency.
-      this.inferenceProfileCache.set(modelId, modelId);
+      // If GetInferenceProfile fails, assume it's a regular model ID. Only
+      // cache definite misses; transient errors and cancellations should retry.
+      if (this.isResourceNotFoundError(error) && !this.isAbortError(error, abortSignal)) {
+        this.inferenceProfileCache.set(modelId, modelId);
+      }
       logger.trace(
         `[Bedrock API Client] GetInferenceProfile failed for ${modelId}, treating as regular model ID`,
         error,
@@ -724,6 +721,29 @@ export class BedrockAPIClient {
       : base;
   }
 
+  private getErrorCode(error: unknown): string | undefined {
+    if (typeof error !== "object" || error === null) {
+      return undefined;
+    }
+
+    const record = error as Record<string, unknown>;
+    const code = record.code ?? record.Code ?? record.name;
+    return typeof code === "string" ? code : undefined;
+  }
+
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
+  private getHttpStatusCode(error: unknown): number | undefined {
+    if (typeof error !== "object" || error === null) {
+      return undefined;
+    }
+
+    const metadata = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
+    return metadata?.httpStatusCode;
+  }
+
   private getProfileCredentialsProvider(
     profile: string,
     options?: { stsRegion?: string },
@@ -758,12 +778,42 @@ export class BedrockAPIClient {
     return wrapped;
   }
 
+  private isAbortError(error: unknown, abortSignal?: AbortSignal): boolean {
+    return abortSignal?.aborted === true || (error instanceof Error && error.name === "AbortError");
+  }
+
+  private isResourceNotFoundError(error: unknown): boolean {
+    return (
+      this.getHttpStatusCode(error) === 404 ||
+      this.getErrorCode(error) === "ResourceNotFoundException"
+    );
+  }
+
+  private isUnsupportedCountTokensError(error: unknown, abortSignal?: AbortSignal): boolean {
+    if (this.isAbortError(error, abortSignal)) {
+      return false;
+    }
+
+    if (this.isResourceNotFoundError(error)) {
+      return true;
+    }
+
+    const code = this.getErrorCode(error);
+    const message = this.getErrorMessage(error);
+    return (
+      code === "ValidationException" &&
+      /count\s*tokens|counttokens/i.test(message) &&
+      /not supported|unsupported|not available/i.test(message)
+    );
+  }
+
   private recreateClients(): void {
     this.bedrockClient = new BedrockClient(this.getClientConfig());
     this.bedrockRuntimeClient = new BedrockRuntimeClient(this.getClientConfig());
 
-    // Clear inference profile cache since profiles may differ across regions/credentials
+    // Clear context-scoped caches since model support can differ across regions/credentials
     this.inferenceProfileCache.clear();
+    this.unsupportedCountTokensModels.clear();
   }
 
   /**

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -361,10 +361,14 @@ export class BedrockAPIClient {
 
     // Check if this looks like an inference profile
     // Patterns:
-    // - Regional/Global: starts with 2-3 letter region code or "global" (us.*, eu.*, global.*)
+    // - Regional/Global: starts with a 2-letter AWS region prefix or "global"
+    //   (us., eu., ap., ca., sa., me., af., il., cn., global.)
+    //   Restricted to known prefixes so we don't false-positive on vendor IDs
+    //   like `zai.glm-5` (zai is 3 letters but is NOT an AWS region prefix).
     // - Application: starts with "ip-" (ip-...)
-    // - ARN: full ARN format (arn:aws:bedrock:region:account:inference-profile/... or application-inference-profile/...)
-    const dotProfilePattern = /^(global|[a-z]{2,3})\./;
+    // - ARN: full ARN format (arn:aws:bedrock:region:account:inference-profile/...
+    //   or application-inference-profile/...)
+    const dotProfilePattern = /^(global|us|eu|ap|ca|sa|me|af|il|cn)\./;
     const arnProfilePattern =
       /^arn:aws(-[a-z0-9]+)?:bedrock:[a-z0-9-]+:\d{12}:(application-)?inference-profile\//;
     const appProfileIdPattern = /^ip-[a-z0-9]+/i;
@@ -398,8 +402,11 @@ export class BedrockAPIClient {
 
       return baseModelId;
     } catch (error) {
-      // If GetInferenceProfile fails, assume it's a regular model ID
-      // This could happen if the ID format looks like a profile but isn't, or if we don't have permissions
+      // If GetInferenceProfile fails, assume it's a regular model ID.
+      // Cache the negative result (mapping to itself) so we don't hammer the
+      // API on every token-count call -- Copilot Chat issues many of those
+      // per turn and each round-trip adds noticeable latency.
+      this.inferenceProfileCache.set(modelId, modelId);
       logger.trace(
         `[Bedrock API Client] GetInferenceProfile failed for ${modelId}, treating as regular model ID`,
         error,

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -740,8 +740,11 @@ export class BedrockAPIClient {
       return undefined;
     }
 
-    const metadata = (error as { $metadata?: { httpStatusCode?: number } }).$metadata;
-    return metadata?.httpStatusCode;
+    const errorWithStatus = error as {
+      $metadata?: { httpStatusCode?: number };
+      $response?: { statusCode?: number };
+    };
+    return errorWithStatus.$metadata?.httpStatusCode ?? errorWithStatus.$response?.statusCode;
   }
 
   private getProfileCredentialsProvider(
@@ -802,8 +805,10 @@ export class BedrockAPIClient {
     const message = this.getErrorMessage(error);
     return (
       code === "ValidationException" &&
-      /count\s*tokens|counttokens/i.test(message) &&
-      /not supported|unsupported|not available/i.test(message)
+      /count\s*tokens|counttokens|token counting/i.test(message) &&
+      /does not (?:currently )?support|not supported|unsupported|not available|not yet enabled/i.test(
+        message,
+      )
     );
   }
 

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -52,6 +52,14 @@ export class BedrockAPIClient {
 
   private region: string;
 
+  // Cache of model IDs for which the CountTokens API is unsupported in the current
+  // region/partition (e.g. some application inference profiles, or newer models that
+  // have not yet been added to CountTokens). Once we see the first failure we stop
+  // hitting the network for subsequent calls -- Copilot Chat invokes
+  // provideTokenCount many times per turn while assembling tool-heavy requests, so
+  // retrying every call adds perceptible latency and log noise.
+  private readonly unsupportedCountTokensModels = new Set<string>();
+
   constructor(region: string, profileName?: string) {
     this.region = region;
     this.profileName = profileName;
@@ -75,9 +83,25 @@ export class BedrockAPIClient {
     input: CountTokensCommandInput["input"],
     abortSignal?: AbortSignal,
   ): Promise<number | undefined> {
+    // If we already know CountTokens is unsupported for this model in this region,
+    // short-circuit so the caller can fall back to estimation without hitting the
+    // network.
+    if (this.unsupportedCountTokensModels.has(modelId)) {
+      return undefined;
+    }
+
+    let baseModelId: string | undefined;
     try {
       // Resolve the base model ID (uses GetInferenceProfile API for cross-region profiles)
-      const baseModelId = await this.resolveModelId(modelId, abortSignal);
+      baseModelId = await this.resolveModelId(modelId, abortSignal);
+
+      // Also check the resolved base model ID -- once we know the underlying
+      // foundation model doesn't support CountTokens, don't re-issue the request
+      // for other inference profiles that resolve to the same base model.
+      if (baseModelId !== modelId && this.unsupportedCountTokensModels.has(baseModelId)) {
+        this.unsupportedCountTokensModels.add(modelId);
+        return undefined;
+      }
 
       const command = new CountTokensCommand({
         input,
@@ -93,6 +117,16 @@ export class BedrockAPIClient {
 
       return response.inputTokens;
     } catch (error) {
+      // Don't cache cancellations -- the user just aborted this particular call.
+      const isAbort =
+        error instanceof Error && (error.name === "AbortError" || abortSignal?.aborted);
+      if (!isAbort) {
+        this.unsupportedCountTokensModels.add(modelId);
+        if (baseModelId && baseModelId !== modelId) {
+          this.unsupportedCountTokensModels.add(baseModelId);
+        }
+      }
+
       // Log detailed error information at trace level for debugging
       logger.trace(`[Bedrock API Client] CountTokens failed for model ${modelId}`, {
         error:
@@ -106,9 +140,11 @@ export class BedrockAPIClient {
         modelId,
       });
 
-      // If the CountTokens API is not supported for this model/region, return undefined
-      // The caller should fall back to estimation
-      logger.debug(
+      // If the CountTokens API is not supported for this model/region, return undefined.
+      // The caller should fall back to estimation. Logged at trace level because Copilot
+      // Chat calls provideTokenCount many times per turn -- one line per call would
+      // flood the output channel.
+      logger.trace(
         `[Bedrock API Client] CountTokens not available for model ${modelId}: ${
           error instanceof Error ? error.message : String(error)
         }`,

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -315,6 +315,15 @@ export function getModelTokenLimits(modelId: string, enable1MContext = false): M
 }
 
 /**
+ * Check if a model needs the 1M context beta header when 1M context is enabled.
+ * Claude Opus 4.7 is 1M-by-default and must not receive the beta header.
+ */
+export function requires1MContextBetaHeader(modelId: string): boolean {
+  const normalizedModelId = normalizeModelId(modelId);
+  return normalizedModelId.includes("opus-4-6") || normalizedModelId.includes("sonnet-4");
+}
+
+/**
  * Get token limits for a Claude model based on its normalized model ID
  */
 function getClaudeTokenLimits(
@@ -427,14 +436,11 @@ function normalizeModelId(modelId: string): string {
 /**
  * Check if a model supports 1M context window
  * Claude Opus 4.7 (always), Opus 4.6, Sonnet 4.6, and Sonnet 4.x models support
- * extended 1M context via anthropic_beta parameter.
+ * extended 1M context.
  */
 function supports1MContext(modelId: string): boolean {
-  return (
-    modelId.includes("opus-4-7") ||
-    modelId.includes("opus-4-6") ||
-    modelId.includes("sonnet-4")
-  );
+  const normalizedModelId = normalizeModelId(modelId);
+  return normalizedModelId.includes("opus-4-7") || requires1MContextBetaHeader(normalizedModelId);
 }
 
 /**

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -374,10 +374,10 @@ function getClaudeTokenLimits(
     return { maxInputTokens: 200_000 - 64_000, maxOutputTokens: 64_000 };
   }
 
-  // Claude Opus 4.1: 200K context, 32K output (AWS-verified limit: 32000)
+  // Claude Opus 4.1: 200K context, 32K output (AWS-verified limit: 32768)
   // Upstream previously used 64K output; Anthropic's published limit is 32K.
   if (normalizedModelId.includes("opus-4-1")) {
-    return { maxInputTokens: 200_000 - 32_000, maxOutputTokens: 32_000 };
+    return { maxInputTokens: 200_000 - 32_768, maxOutputTokens: 32_768 };
   }
 
   // Claude Opus 4: 200K context, 32K output (AWS-verified limit: 32768)

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -161,7 +161,8 @@ export function getModelProfile(modelId: string): ModelProfile {
 
       // Interleaved thinking (beta header) is only for Claude 4 models
       const requiresInterleavedThinkingHeader =
-        modelId.includes("opus-4") || modelId.includes("sonnet-4");
+        (modelId.includes("opus-4") && !modelId.includes("opus-4-7")) ||
+        modelId.includes("sonnet-4");
 
       // Claude models with extended thinking have issues with cachePoint after toolResult
       // When extended thinking is enabled, cachePoint should only be added to messages without toolResult

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -244,6 +244,15 @@ function getClaudeTokenLimits(
   normalizedModelId: string,
   enable1MContext: boolean,
 ): ModelTokenLimits {
+  // Claude Opus 4.7: always 1M context, 128K max output (per Anthropic docs).
+  // Opus 4.7 does not require the context-1m-* beta header -- 1M is the default.
+  if (normalizedModelId.includes("opus-4-7")) {
+    return {
+      maxInputTokens: 1_000_000 - 128_000,
+      maxOutputTokens: 128_000,
+    };
+  }
+
   // Claude Opus 4.6: 200K context (or 1M with setting enabled), 128K max output
   // https://platform.claude.com - Opus 4.6 supports 128K output and optional 1M context
   if (normalizedModelId.includes("opus-4-6")) {
@@ -274,9 +283,21 @@ function getClaudeTokenLimits(
     return { maxInputTokens: 200_000 - 64_000, maxOutputTokens: 64_000 };
   }
 
-  // Claude Opus 4.5, 4.1 and 4: 200K context, 64K output
-  if (normalizedModelId.includes("opus-4")) {
+  // Claude Opus 4.5: 200K context, 64K output (per Anthropic docs)
+  if (normalizedModelId.includes("opus-4-5")) {
     return { maxInputTokens: 200_000 - 64_000, maxOutputTokens: 64_000 };
+  }
+
+  // Claude Opus 4.1: 200K context, 32K output (AWS-verified limit: 32000)
+  // Upstream previously used 64K output; Anthropic's published limit is 32K.
+  if (normalizedModelId.includes("opus-4-1")) {
+    return { maxInputTokens: 200_000 - 32_000, maxOutputTokens: 32_000 };
+  }
+
+  // Claude Opus 4: 200K context, 32K output (AWS-verified limit: 32768)
+  // Upstream previously used 64K output; Anthropic's published limit is 32K.
+  if (normalizedModelId.includes("opus-4")) {
+    return { maxInputTokens: 200_000 - 32_768, maxOutputTokens: 32_768 };
   }
 
   // Claude Haiku 4.5: 200K context, 64K output
@@ -328,10 +349,15 @@ function normalizeModelId(modelId: string): string {
 
 /**
  * Check if a model supports 1M context window
- * Claude Opus 4.6, Sonnet 4.6, and Sonnet 4.x models support extended 1M context via anthropic_beta parameter
+ * Claude Opus 4.7 (always), Opus 4.6, Sonnet 4.6, and Sonnet 4.x models support
+ * extended 1M context via anthropic_beta parameter.
  */
 function supports1MContext(modelId: string): boolean {
-  return modelId.includes("opus-4-6") || modelId.includes("sonnet-4");
+  return (
+    modelId.includes("opus-4-7") ||
+    modelId.includes("opus-4-6") ||
+    modelId.includes("sonnet-4")
+  );
 }
 
 /**

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -124,12 +124,15 @@ export function getModelProfile(modelId: string): ModelProfile {
     }
     case "anthropic": {
       // Claude models support tool choice and prompt caching
-      // Extended thinking is supported by Claude Opus 4+, Sonnet 4+, and Sonnet 3.7
+      // Extended thinking is supported by Claude Opus 4+, Sonnet 4+, Sonnet 3.7,
+      // and Haiku 4.5
       const supportsThinking =
         modelId.includes("opus-4") ||
         modelId.includes("sonnet-4") ||
         modelId.includes("sonnet-3-7") ||
-        modelId.includes("sonnet-3.7");
+        modelId.includes("sonnet-3.7") ||
+        modelId.includes("haiku-4-5") ||
+        modelId.includes("haiku-4.5");
 
       // Interleaved thinking (beta header) is only for Claude 4 models
       const requiresInterleavedThinkingHeader =

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -28,6 +28,16 @@ export interface ModelProfile {
    */
   supportsPromptCaching: boolean;
   /**
+   * Whether the model accepts the OpenAI-style `reasoning_effort` field via
+   * additionalModelRequestFields. Valid values: low | medium | high (and
+   * `minimal` for OpenAI gpt-oss only -- handled at the call site).
+   *
+   * Only opt in when CLI-verified that the model actually produces reasoning
+   * content for the parameter; models that silently ignore the field (e.g.
+   * Mistral, Google Gemma, NVIDIA Nemotron) should leave this false.
+   */
+  supportsReasoningEffort: boolean;
+  /**
    * Whether the model supports extended thinking (Claude Opus 4.6, Opus 4.5, Opus 4.1, Opus 4, Sonnet 4.6, Sonnet 4.5, Sonnet 4, Sonnet 3.7)
    */
   supportsThinking: boolean;
@@ -75,6 +85,7 @@ export function getModelProfile(modelId: string): ModelProfile {
     supports1MContext: false,
     supportsCachingWithToolResults: false,
     supportsPromptCaching: false,
+    supportsReasoningEffort: false,
     supportsThinking: false,
     supportsThinkingEffort: false,
     supportsToolChoice: false,
@@ -112,6 +123,7 @@ export function getModelProfile(modelId: string): ModelProfile {
           supports1MContext: false,
           supportsCachingWithToolResults: false,
           supportsPromptCaching: true,
+          supportsReasoningEffort: false,
           supportsThinking: false,
           supportsThinkingEffort: false,
           supportsToolChoice: true,
@@ -167,6 +179,7 @@ export function getModelProfile(modelId: string): ModelProfile {
         supports1MContext: supports1MContext(modelId),
         supportsCachingWithToolResults,
         supportsPromptCaching: true,
+        supportsReasoningEffort: false, // Anthropic uses thinking.* / output_config.effort, not reasoning_effort
         supportsThinking,
         supportsThinkingEffort,
         supportsToolChoice: true,
@@ -183,6 +196,7 @@ export function getModelProfile(modelId: string): ModelProfile {
         supports1MContext: false,
         supportsCachingWithToolResults: false,
         supportsPromptCaching: false,
+        supportsReasoningEffort: false,
         supportsThinking: false,
         supportsThinkingEffort: false,
         supportsToolChoice: false,
@@ -193,13 +207,16 @@ export function getModelProfile(modelId: string): ModelProfile {
     }
 
     case "openai": {
-      // OpenAI models support tool choice but not prompt caching
+      // OpenAI gpt-oss models support tool choice AND the OpenAI-style
+      // `reasoning_effort` parameter (CLI-verified: low | medium | high work;
+      // `minimal` is OpenAI-only; `max` is rejected).
       return {
         requiresAdaptiveThinking: false,
         requiresInterleavedThinkingHeader: false,
         supports1MContext: false,
         supportsCachingWithToolResults: false,
         supportsPromptCaching: false,
+        supportsReasoningEffort: true,
         supportsThinking: false,
         supportsThinkingEffort: false,
         supportsToolChoice: true,

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -103,14 +103,26 @@ export function getModelProfile(modelId: string): ModelProfile {
 
   const provider = parts[0];
 
-  // Provider-specific profiles
+  // Provider-specific profiles. Cases are alphabetical to satisfy the
+  // perfectionist/sort-switch-case lint rule.
   switch (provider) {
     case "ai21":
-
     case "cohere":
-    case "meta": {
-      // Older models don't support tool choice
-      return defaultProfile;
+    case "google":
+    case "meta":
+    case "nvidia": {
+      // CLI-verified tool-calling opt-ins with no reasoning/thinking support:
+      // - AI21 Jamba 1.5 supports tool calling
+      // - Cohere Command R/R+ support tool calling
+      // - Google Gemma 3 supports tool calling (reasoning_effort silently
+      //   ignored, so not advertised)
+      // - Meta Llama 3/3.1/3.2/3.3/4 all support tool calling via Converse
+      // - NVIDIA Nemotron supports tool calling (reasoning_effort silently
+      //   ignored, no reasoningContent emitted -- not advertised)
+      //
+      // Older J2/Command/Llama2 variants that predate tool calling are no
+      // longer surfaced on current Bedrock, so the blanket opt-in is safe.
+      return { ...defaultProfile, supportsToolChoice: true };
     }
 
     case "amazon": {
@@ -134,6 +146,7 @@ export function getModelProfile(modelId: string): ModelProfile {
       }
       return defaultProfile;
     }
+
     case "anthropic": {
       // Claude models support tool choice and prompt caching
       // Extended thinking is supported by Claude Opus 4+, Sonnet 4+, Sonnet 3.7,
@@ -188,8 +201,46 @@ export function getModelProfile(modelId: string): ModelProfile {
         toolResultFormat: "text",
       };
     }
+
+    case "deepseek": {
+      // CLI-verified: DeepSeek V3.2 supports tool calling and the
+      // reasoning_effort parameter. DeepSeek R1 is a reasoning-only model
+      // with always-on thinking -- it rejects tool configs and the
+      // reasoning_effort parameter, so we opt it out of both.
+      const isR1 = modelId.includes("r1");
+      return {
+        ...defaultProfile,
+        supportsReasoningEffort: !isR1,
+        supportsToolChoice: !isR1,
+      };
+    }
+
+    case "minimax":
+    case "moonshot":
+    case "moonshotai":
+    case "qwen":
+    case "zai": {
+      // CLI-verified: all of MiniMax M2.x, Moonshot Kimi K2.x, Qwen3
+      // (dense/VL/Coder/Next), and Z.AI GLM 4.7/5 support both tool calling
+      // and the OpenAI-style reasoning_effort parameter via Converse.
+      return {
+        ...defaultProfile,
+        supportsReasoningEffort: true,
+        supportsToolChoice: true,
+      };
+    }
+
     case "mistral": {
-      // Mistral models require JSON format for tool results
+      // CLI-verified: modern Mistral models on Bedrock (Large 3, Pixtral Large,
+      // Magistral, Ministral 3, Devstral 2, Voxtral) all support tool calling
+      // via the Converse API. The two legacy models -- mistral-7b-instruct and
+      // mixtral-8x7b-instruct -- predate tool calling and are still listed by
+      // Bedrock; they must be opted out individually.
+      //
+      // Mistral expects tool results in JSON form rather than plain text.
+      // reasoning_effort is silently ignored on this family.
+      const isLegacyNonTool =
+        modelId.includes("mistral-7b-instruct") || modelId.includes("mixtral-8x7b-instruct");
       return {
         requiresAdaptiveThinking: false,
         requiresInterleavedThinkingHeader: false,
@@ -199,7 +250,7 @@ export function getModelProfile(modelId: string): ModelProfile {
         supportsReasoningEffort: false,
         supportsThinking: false,
         supportsThinkingEffort: false,
-        supportsToolChoice: false,
+        supportsToolChoice: !isLegacyNonTool,
         supportsToolResultStatus: false,
         temperatureDeprecated: false,
         toolResultFormat: "json",
@@ -224,6 +275,15 @@ export function getModelProfile(modelId: string): ModelProfile {
         temperatureDeprecated: false,
         toolResultFormat: "text",
       };
+    }
+
+    case "writer": {
+      // CLI-verified: Palmyra X4/X5 support tool calling (via inference
+      // profile). Palmyra Vision 7B is vision-only and rejects tool configs.
+      if (modelId.includes("vision")) {
+        return defaultProfile;
+      }
+      return { ...defaultProfile, supportsToolChoice: true };
     }
 
     default: {

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -4,6 +4,12 @@
 
 export interface ModelProfile {
   /**
+   * Whether the model requires adaptive thinking (thinking.type="adaptive") instead of
+   * the usual thinking.type="enabled" with budget_tokens.
+   * CLI-verified: only Claude Opus 4.7 requires this.
+   */
+  requiresAdaptiveThinking: boolean;
+  /**
    * Whether the model requires the interleaved-thinking beta header (Claude 4 models only)
    */
   requiresInterleavedThinkingHeader: boolean;
@@ -41,6 +47,11 @@ export interface ModelProfile {
    */
   supportsToolResultStatus: boolean;
   /**
+   * Whether the temperature parameter is deprecated and must be omitted from requests.
+   * CLI-verified: only Claude Opus 4.7 rejects requests that include `temperature`.
+   */
+  temperatureDeprecated: boolean;
+  /**
    * Format to use for tool result content ('text' or 'json')
    */
   toolResultFormat: "json" | "text";
@@ -59,6 +70,7 @@ export interface ModelTokenLimits {
 
 export function getModelProfile(modelId: string): ModelProfile {
   const defaultProfile: ModelProfile = {
+    requiresAdaptiveThinking: false,
     requiresInterleavedThinkingHeader: false,
     supports1MContext: false,
     supportsCachingWithToolResults: false,
@@ -67,6 +79,7 @@ export function getModelProfile(modelId: string): ModelProfile {
     supportsThinkingEffort: false,
     supportsToolChoice: false,
     supportsToolResultStatus: false,
+    temperatureDeprecated: false,
     toolResultFormat: "text",
   };
 
@@ -94,6 +107,7 @@ export function getModelProfile(modelId: string): ModelProfile {
       // Nova does NOT support cachePoint after toolResult blocks
       if (modelId.includes("nova")) {
         return {
+          requiresAdaptiveThinking: false,
           requiresInterleavedThinkingHeader: false,
           supports1MContext: false,
           supportsCachingWithToolResults: false,
@@ -102,6 +116,7 @@ export function getModelProfile(modelId: string): ModelProfile {
           supportsThinkingEffort: false,
           supportsToolChoice: true,
           supportsToolResultStatus: false,
+          temperatureDeprecated: false,
           toolResultFormat: "text",
         };
       }
@@ -124,14 +139,27 @@ export function getModelProfile(modelId: string): ModelProfile {
       // When extended thinking is enabled, cachePoint should only be added to messages without toolResult
       const supportsCachingWithToolResults = !supportsThinking;
 
-      // Adaptive thinking / thinking effort parameter is supported by Claude Opus 4.6, Opus 4.5, and Sonnet 4.6
+      // Adaptive thinking / thinking effort parameter is supported by
+      // Claude Opus 4.7, Opus 4.6, Opus 4.5, and Sonnet 4.6
       // Allows controlling token expenditure with "high", "medium", or "low" effort levels
       const supportsThinkingEffort =
+        modelId.includes("opus-4-7") ||
         modelId.includes("opus-4-6") ||
         modelId.includes("opus-4-5") ||
         modelId.includes("sonnet-4-6");
 
+      // CLI-verified: Opus 4.7 rejects `thinking.type="enabled"` and requires
+      // `thinking.type="adaptive"` (with no budget_tokens). All other Claude
+      // models still use enabled+budget.
+      const requiresAdaptiveThinking = modelId.includes("opus-4-7");
+
+      // CLI-verified: Opus 4.7 rejects requests that include the `temperature`
+      // inference parameter (Bedrock returns a ValidationException). All other
+      // Claude models still accept temperature.
+      const temperatureDeprecated = modelId.includes("opus-4-7");
+
       return {
+        requiresAdaptiveThinking,
         requiresInterleavedThinkingHeader,
         supports1MContext: supports1MContext(modelId),
         supportsCachingWithToolResults,
@@ -140,12 +168,14 @@ export function getModelProfile(modelId: string): ModelProfile {
         supportsThinkingEffort,
         supportsToolChoice: true,
         supportsToolResultStatus: true, // Claude models support status field in tool results
+        temperatureDeprecated,
         toolResultFormat: "text",
       };
     }
     case "mistral": {
       // Mistral models require JSON format for tool results
       return {
+        requiresAdaptiveThinking: false,
         requiresInterleavedThinkingHeader: false,
         supports1MContext: false,
         supportsCachingWithToolResults: false,
@@ -154,6 +184,7 @@ export function getModelProfile(modelId: string): ModelProfile {
         supportsThinkingEffort: false,
         supportsToolChoice: false,
         supportsToolResultStatus: false,
+        temperatureDeprecated: false,
         toolResultFormat: "json",
       };
     }
@@ -161,6 +192,7 @@ export function getModelProfile(modelId: string): ModelProfile {
     case "openai": {
       // OpenAI models support tool choice but not prompt caching
       return {
+        requiresAdaptiveThinking: false,
         requiresInterleavedThinkingHeader: false,
         supports1MContext: false,
         supportsCachingWithToolResults: false,
@@ -169,6 +201,7 @@ export function getModelProfile(modelId: string): ModelProfile {
         supportsThinkingEffort: false,
         supportsToolChoice: true,
         supportsToolResultStatus: false,
+        temperatureDeprecated: false,
         toolResultFormat: "text",
       };
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1448,9 +1448,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     let thinkingDescription: string | undefined;
     if (profile.requiresAdaptiveThinking) {
       thinkingDescription = "adaptive thinking";
-    } else if (profile.supportsThinkingEffort) {
-      thinkingDescription = "budget thinking";
-    } else if (profile.supportsThinking) {
+    } else if (profile.supportsThinkingEffort || profile.supportsThinking) {
       thinkingDescription = "budget thinking";
     }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -24,7 +24,7 @@ import { convertMessages, stripThinkingContent } from "./converters/messages";
 import { convertTools } from "./converters/tools";
 import { logger } from "./logger";
 import { getModelProfile, getModelTokenLimits } from "./profiles";
-import { getBedrockSettings } from "./settings";
+import { getBedrockSettings, type ReasoningEffort } from "./settings";
 import { StreamProcessor, type ThinkingBlock } from "./stream-processor";
 import type { AuthConfig, AuthMethod, BedrockModelSummary } from "./types";
 import { validateBedrockMessages } from "./validation";
@@ -592,6 +592,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         thinkingEffortEnabled ? settings.thinking.effort : undefined,
         modelProfile.temperatureDeprecated,
         modelProfile.requiresAdaptiveThinking,
+        modelProfile.supportsReasoningEffort ? settings.reasoningEffort : undefined,
       );
 
       // Log request details
@@ -920,6 +921,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     thinkingEffort?: "high" | "low" | "medium",
     temperatureDeprecated?: boolean,
     requiresAdaptiveThinking?: boolean,
+    reasoningEffort?: ReasoningEffort,
   ): ConverseStreamCommandInput {
     const requestInput: ConverseStreamCommandInput = {
       inferenceConfig: {
@@ -972,6 +974,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       thinkingEffort,
       temperatureDeprecated,
       requiresAdaptiveThinking,
+      reasoningEffort,
     );
 
     return requestInput;
@@ -1015,7 +1018,28 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     thinkingEffort?: "high" | "low" | "medium",
     temperatureDeprecated?: boolean,
     requiresAdaptiveThinking?: boolean,
+    reasoningEffort?: ReasoningEffort,
   ): void {
+    const applyReasoningEffort = (): void => {
+      if (!reasoningEffort) {
+        return;
+      }
+      // OpenAI gpt-oss accepts `minimal`; other providers only accept low/medium/high,
+      // so clamp `minimal` to `low` for non-OpenAI models.
+      const resolved =
+        reasoningEffort === "minimal" && !modelId.startsWith("openai.")
+          ? "low"
+          : reasoningEffort;
+      requestInput.additionalModelRequestFields = {
+        ...((requestInput.additionalModelRequestFields ?? {}) as Record<string, unknown>),
+        reasoning_effort: resolved,
+      };
+      logger.debug("[Bedrock Model Provider] reasoning_effort set", {
+        modelId,
+        reasoningEffort: resolved,
+      });
+    };
+
     if (extendedThinkingEnabled) {
       // Extended thinking normally requires temperature 1.0, but Claude Opus 4.7
       // rejects any `temperature` parameter. For all other models, force 1.0.
@@ -1048,6 +1072,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         thinkingEffort: thinkingEffort ?? "(not applicable)",
         thinkingType: requiresAdaptiveThinking ? "adaptive" : "enabled",
       });
+      applyReasoningEffort();
       return;
     }
 
@@ -1064,6 +1089,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         modelId,
         thinkingEffort,
       });
+      applyReasoningEffort();
       return;
     }
 
@@ -1075,6 +1101,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
       logger.debug("[Bedrock Model Provider] 1M context enabled", { modelId });
     }
+
+    applyReasoningEffort();
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,20 +1,20 @@
 import { ModelModality } from "@aws-sdk/client-bedrock";
 import type {
-  ConverseStreamCommandInput,
-  CountTokensCommandInput,
-  Message,
-  SystemContentBlock,
-  ToolConfiguration,
+    ConverseStreamCommandInput,
+    CountTokensCommandInput,
+    Message,
+    SystemContentBlock,
+    ToolConfiguration,
 } from "@aws-sdk/client-bedrock-runtime";
 import { inspect, MIMEType } from "node:util";
 import type {
-  CancellationToken,
-  LanguageModelChatInformation,
-  LanguageModelChatMessage,
-  LanguageModelChatProvider,
-  LanguageModelResponsePart,
-  LanguageModelResponsePart2,
-  Progress,
+    CancellationToken,
+    LanguageModelChatInformation,
+    LanguageModelChatMessage,
+    LanguageModelChatProvider,
+    LanguageModelResponsePart,
+    LanguageModelResponsePart2,
+    Progress,
 } from "vscode";
 import * as vscode from "vscode";
 
@@ -217,11 +217,14 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             const vision = m.inputModalities.includes(ModelModality.IMAGE);
 
             // Classify the invocation route so the tooltip can state it plainly.
-            const route = hasInferenceProfile
-              ? modelIdToUse.startsWith("global.")
-                ? "Global inference profile"
-                : "Local/regional inference profile"
-              : "Direct foundation model";
+            let route: string;
+            if (!hasInferenceProfile) {
+              route = "Direct foundation model";
+            } else if (modelIdToUse.startsWith("global.")) {
+              route = "Global inference profile";
+            } else {
+              route = "Local/regional inference profile";
+            }
 
             const modelInfo: LanguageModelChatInformation = {
               capabilities: {
@@ -772,6 +775,81 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   }
 
   /**
+   * Apply extended-thinking-related fields (thinking, beta headers, optional
+   * output_config.effort, and the temperature override) to the request input.
+   * Extracted from configureAdditionalModelFields to keep cognitive complexity
+   * below the SonarJS threshold.
+   */
+  private applyExtendedThinkingFields(
+    requestInput: ConverseStreamCommandInput,
+    modelId: string,
+    budgetTokens: number,
+    betaHeaders: string[],
+    thinkingEffort: "high" | "low" | "medium" | undefined,
+    temperatureDeprecated: boolean | undefined,
+    requiresAdaptiveThinking: boolean | undefined,
+  ): void {
+    // Extended thinking normally requires temperature 1.0, but Claude Opus 4.7
+    // rejects any `temperature` parameter. For all other models, force 1.0.
+    if (!temperatureDeprecated) {
+      requestInput.inferenceConfig!.temperature = 1;
+    }
+
+    // CLI-verified: Claude Opus 4.7 rejects thinking.type="enabled" and
+    // requires thinking.type="adaptive" (with no budget_tokens). All other
+    // Claude models still use enabled+budget.
+    const thinkingField: { budget_tokens?: number; type: "adaptive" | "enabled" } =
+      requiresAdaptiveThinking
+        ? { type: "adaptive" }
+        : { budget_tokens: budgetTokens, type: "enabled" };
+
+    requestInput.additionalModelRequestFields = {
+      thinking: thinkingField,
+      ...(betaHeaders.length > 0 ? { anthropic_beta: betaHeaders } : {}),
+      // Add thinking effort for Claude Opus 4.5 and Sonnet 4.6 (controls token expenditure)
+      ...(thinkingEffort ? { output_config: { effort: thinkingEffort } } : {}),
+    };
+
+    logger.debug("[Bedrock Model Provider] Extended thinking enabled", {
+      anthropicBeta: betaHeaders.length > 0 ? betaHeaders : undefined,
+      budgetTokens: requiresAdaptiveThinking ? "(adaptive)" : budgetTokens,
+      interleavedThinking: betaHeaders.includes("interleaved-thinking-2025-05-14"),
+      modelId,
+      supports1MContext: betaHeaders.includes("context-1m-2025-08-07"),
+      temperature: temperatureDeprecated ? "(omitted)" : 1,
+      thinkingEffort: thinkingEffort ?? "(not applicable)",
+      thinkingType: requiresAdaptiveThinking ? "adaptive" : "enabled",
+    });
+  }
+
+  /**
+   * Merge the OpenAI-style `reasoning_effort` field into
+   * additionalModelRequestFields, alongside anything already set by
+   * thinking/beta-header handling. Called last so the field coexists with
+   * Anthropic's `thinking` / `output_config` blocks.
+   *
+   * Only OpenAI gpt-oss accepts `minimal`; for other providers that opted in
+   * (DeepSeek V3.2, Kimi K2.x, Qwen3, GLM, MiniMax) `minimal` is clamped to
+   * `low` to avoid a Converse ValidationException.
+   */
+  private applyReasoningEffort(
+    requestInput: ConverseStreamCommandInput,
+    modelId: string,
+    reasoningEffort: ReasoningEffort,
+  ): void {
+    const resolved =
+      reasoningEffort === "minimal" && !modelId.startsWith("openai.") ? "low" : reasoningEffort;
+    requestInput.additionalModelRequestFields = {
+      ...((requestInput.additionalModelRequestFields ?? {}) as Record<string, unknown>),
+      reasoning_effort: resolved,
+    };
+    logger.debug("[Bedrock Model Provider] reasoning_effort set", {
+      modelId,
+      reasoningEffort: resolved,
+    });
+  }
+
+  /**
    * Build beta headers array for the request
    */
   private buildBetaHeaders(
@@ -803,80 +881,6 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     return anthropicBeta;
-  }
-
-  /**
-   * Build the inline detail string shown next to the model name in the picker.
-   * Format: "<context> ctx · <output>K out · <thinking-mode> · <vision>".
-   * The model ID is used only to consult getModelProfile for capability flags;
-   * display-side values (context and output) are the effective numeric limits.
-   */
-  private formatDetail(
-    modelId: string,
-    maxInput: number,
-    maxOutput: number,
-    vision: boolean,
-  ): string {
-    const profile = getModelProfile(modelId);
-    const ctxK = Math.round((maxInput + maxOutput) / 1000);
-    const outK = Math.round(maxOutput / 1000);
-    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M` : `${ctxK}K`;
-    const parts = [`${ctxLabel} ctx`, `${outK}K out`];
-
-    if (profile.requiresAdaptiveThinking) {
-      parts.push("adaptive thinking");
-    } else if (profile.supportsThinkingEffort) {
-      parts.push("adaptive or budget thinking");
-    } else if (profile.supportsThinking) {
-      parts.push("budget thinking");
-    }
-
-    if (vision) parts.push("vision");
-
-    return parts.join(" \u00B7 ");
-  }
-
-  /**
-   * Build a multi-line tooltip describing the model's capabilities and the
-   * Bedrock invocation route (direct model, regional/global inference profile,
-   * application inference profile, or manual entry). The route is surfaced so
-   * users can distinguish between, e.g., `us.anthropic.claude-opus-4-7` vs
-   * `global.anthropic.claude-opus-4-7` vs the base foundation model.
-   */
-  private formatTooltip(args: {
-    maxInput: number;
-    maxOutput: number;
-    modelId: string;
-    providerName: string;
-    route: string;
-    vision: boolean;
-  }): string {
-    const profile = getModelProfile(args.modelId);
-    const lines: string[] = [`Amazon Bedrock - ${args.providerName}`];
-    lines.push(`Route: ${args.route}`);
-    lines.push(`Model ID: ${args.modelId}`);
-
-    const ctxK = Math.round((args.maxInput + args.maxOutput) / 1000);
-    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M tokens` : `${ctxK}K tokens`;
-    lines.push(`Context: ${ctxLabel} | Max output: ${Math.round(args.maxOutput / 1000)}K tokens`);
-
-    if (profile.requiresAdaptiveThinking) {
-      lines.push("Thinking: adaptive only (uses output_config.effort)");
-    } else if (profile.supportsThinkingEffort) {
-      lines.push("Thinking: adaptive (recommended) or enabled+budget");
-    } else if (profile.supportsThinking) {
-      lines.push("Thinking: enabled+budget_tokens");
-    }
-
-    if (profile.temperatureDeprecated) {
-      lines.push("Note: temperature parameter is not supported");
-    }
-
-    if (args.vision) {
-      lines.push("Vision: image input supported");
-    }
-
-    return lines.join("\n");
   }
 
   /**
@@ -1122,63 +1126,17 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     requiresAdaptiveThinking?: boolean,
     reasoningEffort?: ReasoningEffort,
   ): void {
-    const applyReasoningEffort = (): void => {
-      if (!reasoningEffort) {
-        return;
-      }
-      // OpenAI gpt-oss accepts `minimal`; other providers only accept low/medium/high,
-      // so clamp `minimal` to `low` for non-OpenAI models.
-      const resolved =
-        reasoningEffort === "minimal" && !modelId.startsWith("openai.")
-          ? "low"
-          : reasoningEffort;
-      requestInput.additionalModelRequestFields = {
-        ...((requestInput.additionalModelRequestFields ?? {}) as Record<string, unknown>),
-        reasoning_effort: resolved,
-      };
-      logger.debug("[Bedrock Model Provider] reasoning_effort set", {
-        modelId,
-        reasoningEffort: resolved,
-      });
-    };
-
     if (extendedThinkingEnabled) {
-      // Extended thinking normally requires temperature 1.0, but Claude Opus 4.7
-      // rejects any `temperature` parameter. For all other models, force 1.0.
-      if (!temperatureDeprecated) {
-        requestInput.inferenceConfig!.temperature = 1;
-      }
-
-      // CLI-verified: Claude Opus 4.7 rejects thinking.type="enabled" and
-      // requires thinking.type="adaptive" (with no budget_tokens). All other
-      // Claude models still use enabled+budget.
-      const thinkingField: { budget_tokens?: number; type: "adaptive" | "enabled" } =
-        requiresAdaptiveThinking
-          ? { type: "adaptive" }
-          : { budget_tokens: budgetTokens, type: "enabled" };
-
-      requestInput.additionalModelRequestFields = {
-        thinking: thinkingField,
-        ...(betaHeaders.length > 0 ? { anthropic_beta: betaHeaders } : {}),
-        // Add thinking effort for Claude Opus 4.5 and Sonnet 4.6 (controls token expenditure)
-        ...(thinkingEffort ? { output_config: { effort: thinkingEffort } } : {}),
-      };
-
-      logger.debug("[Bedrock Model Provider] Extended thinking enabled", {
-        anthropicBeta: betaHeaders.length > 0 ? betaHeaders : undefined,
-        budgetTokens: requiresAdaptiveThinking ? "(adaptive)" : budgetTokens,
-        interleavedThinking: betaHeaders.includes("interleaved-thinking-2025-05-14"),
+      this.applyExtendedThinkingFields(
+        requestInput,
         modelId,
-        supports1MContext: betaHeaders.includes("context-1m-2025-08-07"),
-        temperature: temperatureDeprecated ? "(omitted)" : 1,
-        thinkingEffort: thinkingEffort ?? "(not applicable)",
-        thinkingType: requiresAdaptiveThinking ? "adaptive" : "enabled",
-      });
-      applyReasoningEffort();
-      return;
-    }
-
-    if (thinkingEffort) {
+        budgetTokens,
+        betaHeaders,
+        thinkingEffort,
+        temperatureDeprecated,
+        requiresAdaptiveThinking,
+      );
+    } else if (thinkingEffort) {
       // Claude Opus 4.5 and Sonnet 4.6 effort parameter can be used even without extended thinking
       // This affects all token spend including tool calls
       requestInput.additionalModelRequestFields = {
@@ -1191,11 +1149,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         modelId,
         thinkingEffort,
       });
-      applyReasoningEffort();
-      return;
-    }
-
-    if (betaHeaders.length > 0) {
+    } else if (betaHeaders.length > 0) {
       // Add beta headers even without thinking or effort
       requestInput.additionalModelRequestFields = {
         anthropic_beta: betaHeaders,
@@ -1204,7 +1158,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       logger.debug("[Bedrock Model Provider] 1M context enabled", { modelId });
     }
 
-    applyReasoningEffort();
+    if (reasoningEffort) {
+      this.applyReasoningEffort(requestInput, modelId, reasoningEffort);
+    }
   }
 
   /**
@@ -1455,6 +1411,83 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       `[Bedrock Model Provider] No accessible inference profile or base model for ${candidate.model.modelId}`,
     );
     return { ...candidate, isAccessible: false };
+  }
+
+  /**
+   * Build the inline detail string shown next to the model name in the picker.
+   * Format: "<context> ctx · <output>K out · <thinking-mode> · <vision>".
+   * The model ID is used only to consult getModelProfile for capability flags;
+   * display-side values (context and output) are the effective numeric limits.
+   */
+  private formatDetail(
+    modelId: string,
+    maxInput: number,
+    maxOutput: number,
+    vision: boolean,
+  ): string {
+    const profile = getModelProfile(modelId);
+    const ctxK = Math.round((maxInput + maxOutput) / 1000);
+    const outK = Math.round(maxOutput / 1000);
+    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M` : `${ctxK}K`;
+
+    let thinkingDescription: string | undefined;
+    if (profile.requiresAdaptiveThinking) {
+      thinkingDescription = "adaptive thinking";
+    } else if (profile.supportsThinkingEffort) {
+      thinkingDescription = "adaptive or budget thinking";
+    } else if (profile.supportsThinking) {
+      thinkingDescription = "budget thinking";
+    }
+
+    const parts = [
+      `${ctxLabel} ctx`,
+      `${outK}K out`,
+      ...(thinkingDescription ? [thinkingDescription] : []),
+      ...(vision ? ["vision"] : []),
+    ];
+
+    return parts.join(" \u00B7 ");
+  }
+
+  /**
+   * Build a multi-line tooltip describing the model's capabilities and the
+   * Bedrock invocation route (direct model, regional/global inference profile,
+   * application inference profile, or manual entry). The route is surfaced so
+   * users can distinguish between, e.g., `us.anthropic.claude-opus-4-7` vs
+   * `global.anthropic.claude-opus-4-7` vs the base foundation model.
+   */
+  private formatTooltip(args: {
+    maxInput: number;
+    maxOutput: number;
+    modelId: string;
+    providerName: string;
+    route: string;
+    vision: boolean;
+  }): string {
+    const profile = getModelProfile(args.modelId);
+    const ctxK = Math.round((args.maxInput + args.maxOutput) / 1000);
+    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M tokens` : `${ctxK}K tokens`;
+
+    let thinkingLine: string | undefined;
+    if (profile.requiresAdaptiveThinking) {
+      thinkingLine = "Thinking: adaptive only (uses output_config.effort)";
+    } else if (profile.supportsThinkingEffort) {
+      thinkingLine = "Thinking: adaptive (recommended) or enabled+budget";
+    } else if (profile.supportsThinking) {
+      thinkingLine = "Thinking: enabled+budget_tokens";
+    }
+
+    const lines = [
+      `Amazon Bedrock - ${args.providerName}`,
+      `Route: ${args.route}`,
+      `Model ID: ${args.modelId}`,
+      `Context: ${ctxLabel} | Max output: ${Math.round(args.maxOutput / 1000)}K tokens`,
+      ...(thinkingLine ? [thinkingLine] : []),
+      ...(profile.temperatureDeprecated ? ["Note: temperature parameter is not supported"] : []),
+      ...(args.vision ? ["Vision: image input supported"] : []),
+    ];
+
+    return lines.join("\n");
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,20 +1,20 @@
 import { ModelModality } from "@aws-sdk/client-bedrock";
 import type {
-    ConverseStreamCommandInput,
-    CountTokensCommandInput,
-    Message,
-    SystemContentBlock,
-    ToolConfiguration,
+  ConverseStreamCommandInput,
+  CountTokensCommandInput,
+  Message,
+  SystemContentBlock,
+  ToolConfiguration,
 } from "@aws-sdk/client-bedrock-runtime";
 import { inspect, MIMEType } from "node:util";
 import type {
-    CancellationToken,
-    LanguageModelChatInformation,
-    LanguageModelChatMessage,
-    LanguageModelChatProvider,
-    LanguageModelResponsePart,
-    LanguageModelResponsePart2,
-    Progress,
+  CancellationToken,
+  LanguageModelChatInformation,
+  LanguageModelChatMessage,
+  LanguageModelChatProvider,
+  LanguageModelResponsePart,
+  LanguageModelResponsePart2,
+  Progress,
 } from "vscode";
 import * as vscode from "vscode";
 
@@ -23,7 +23,7 @@ import { BedrockAPIClient, ListFoundationModelsDeniedError } from "./bedrock-cli
 import { convertMessages, stripThinkingContent } from "./converters/messages";
 import { convertTools } from "./converters/tools";
 import { logger } from "./logger";
-import { getModelProfile, getModelTokenLimits } from "./profiles";
+import { getModelProfile, getModelTokenLimits, requires1MContextBetaHeader } from "./profiles";
 import { getBedrockSettings, type ReasoningEffort } from "./settings";
 import { StreamProcessor, type ThinkingBlock } from "./stream-processor";
 import type { AuthConfig, AuthMethod, BedrockModelSummary } from "./types";
@@ -593,6 +593,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // Build beta headers
       const betaHeaders = this.buildBetaHeaders(
         modelProfile,
+        baseModelId,
         extendedThinkingEnabled,
         settings.context1M.enabled,
         thinkingEffortEnabled,
@@ -601,6 +602,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // Build request input
       const requestInput = this.buildRequestInput(
         model,
+        baseModelId,
         converted,
         options,
         toolConfig,
@@ -835,15 +837,22 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   private applyReasoningEffort(
     requestInput: ConverseStreamCommandInput,
     modelId: string,
+    baseModelId: string,
     reasoningEffort: ReasoningEffort,
   ): void {
+    const openAiIndex = baseModelId.indexOf("openai.");
+    const normalizedBaseModelId = openAiIndex === -1 ? baseModelId : baseModelId.slice(openAiIndex);
+    const supportsMinimalReasoningEffort =
+      getModelProfile(normalizedBaseModelId).supportsReasoningEffort &&
+      normalizedBaseModelId.startsWith("openai.");
     const resolved =
-      reasoningEffort === "minimal" && !modelId.startsWith("openai.") ? "low" : reasoningEffort;
+      reasoningEffort === "minimal" && !supportsMinimalReasoningEffort ? "low" : reasoningEffort;
     requestInput.additionalModelRequestFields = {
       ...((requestInput.additionalModelRequestFields ?? {}) as Record<string, unknown>),
       reasoning_effort: resolved,
     };
     logger.debug("[Bedrock Model Provider] reasoning_effort set", {
+      baseModelId,
       modelId,
       reasoningEffort: resolved,
     });
@@ -854,11 +863,14 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
    */
   private buildBetaHeaders(
     modelProfile: ReturnType<typeof getModelProfile>,
+    modelId: string,
     extendedThinkingEnabled: boolean,
     context1MEnabled: boolean,
     thinkingEffortEnabled: boolean,
   ): string[] {
     const anthropicBeta: string[] = [];
+    const shouldAdd1MContextBetaHeader =
+      modelProfile.supports1MContext && context1MEnabled && requires1MContextBetaHeader(modelId);
 
     if (extendedThinkingEnabled) {
       // Add interleaved-thinking beta header for Claude 4 models
@@ -866,12 +878,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         anthropicBeta.push("interleaved-thinking-2025-05-14");
       }
 
-      // Add 1M context beta header for models that support it and setting is enabled
-      if (modelProfile.supports1MContext && context1MEnabled) {
+      // Add 1M context beta header only for models that require the beta opt-in.
+      if (shouldAdd1MContextBetaHeader) {
         anthropicBeta.push("context-1m-2025-08-07");
       }
-    } else if (modelProfile.supports1MContext && context1MEnabled) {
-      // Even if thinking is not enabled, add 1M context beta header
+    } else if (shouldAdd1MContextBetaHeader) {
+      // Even if thinking is not enabled, add the 1M context beta header when required.
       anthropicBeta.push("context-1m-2025-08-07");
     }
 
@@ -1018,6 +1030,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
    */
   private buildRequestInput(
     model: LanguageModelChatInformation,
+    baseModelId: string,
     converted: { messages: Message[]; system: SystemContentBlock[] },
     options: Parameters<LanguageModelChatProvider["provideLanguageModelChatResponse"]>[2],
     toolConfig: ToolConfiguration | undefined,
@@ -1074,6 +1087,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     this.configureAdditionalModelFields(
       requestInput,
       model.id,
+      baseModelId,
       extendedThinkingEnabled,
       budgetTokens,
       betaHeaders,
@@ -1118,6 +1132,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   private configureAdditionalModelFields(
     requestInput: ConverseStreamCommandInput,
     modelId: string,
+    baseModelId: string,
     extendedThinkingEnabled: boolean,
     budgetTokens: number,
     betaHeaders: string[],
@@ -1159,7 +1174,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     if (reasoningEffort) {
-      this.applyReasoningEffort(requestInput, modelId, reasoningEffort);
+      this.applyReasoningEffort(requestInput, modelId, baseModelId, reasoningEffort);
     }
   }
 
@@ -1434,7 +1449,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     if (profile.requiresAdaptiveThinking) {
       thinkingDescription = "adaptive thinking";
     } else if (profile.supportsThinkingEffort) {
-      thinkingDescription = "adaptive or budget thinking";
+      thinkingDescription = "budget thinking";
     } else if (profile.supportsThinking) {
       thinkingDescription = "budget thinking";
     }
@@ -1472,7 +1487,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     if (profile.requiresAdaptiveThinking) {
       thinkingLine = "Thinking: adaptive only (uses output_config.effort)";
     } else if (profile.supportsThinkingEffort) {
-      thinkingLine = "Thinking: adaptive (recommended) or enabled+budget";
+      thinkingLine = "Thinking: enabled+budget_tokens with effort setting";
     } else if (profile.supportsThinking) {
       thinkingLine = "Thinking: enabled+budget_tokens";
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -690,7 +690,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       let baseModelId: string;
       try {
         baseModelId = await this.client.resolveModelId(model.id, abortController.signal);
-        logger.debug("[Bedrock Model Provider] Resolved model ID", {
+        // trace level: provideTokenCount runs many times per turn, this would flood the log
+        logger.trace("[Bedrock Model Provider] Resolved model ID", {
           originalModelId: model.id,
           resolvedBaseModelId: baseModelId,
         });

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -590,6 +590,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         budgetTokens,
         betaHeaders,
         thinkingEffortEnabled ? settings.thinking.effort : undefined,
+        modelProfile.temperatureDeprecated,
+        modelProfile.requiresAdaptiveThinking,
       );
 
       // Log request details
@@ -916,6 +918,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     budgetTokens: number,
     betaHeaders: string[],
     thinkingEffort?: "high" | "low" | "medium",
+    temperatureDeprecated?: boolean,
+    requiresAdaptiveThinking?: boolean,
   ): ConverseStreamCommandInput {
     const requestInput: ConverseStreamCommandInput = {
       inferenceConfig: {
@@ -925,10 +929,14 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             : model.maxOutputTokens,
           model.maxOutputTokens,
         ),
-        temperature:
-          typeof options.modelOptions?.temperature === "number"
-            ? options.modelOptions?.temperature
-            : 0.7,
+        // CLI-verified: Claude Opus 4.7 rejects requests that include
+        // `temperature`. All other models still accept it.
+        ...(!temperatureDeprecated && {
+          temperature:
+            typeof options.modelOptions?.temperature === "number"
+              ? options.modelOptions?.temperature
+              : 0.7,
+        }),
       },
       messages: converted.messages,
       modelId: model.id,
@@ -962,6 +970,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       budgetTokens,
       betaHeaders,
       thinkingEffort,
+      temperatureDeprecated,
+      requiresAdaptiveThinking,
     );
 
     return requestInput;
@@ -1003,17 +1013,26 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     budgetTokens: number,
     betaHeaders: string[],
     thinkingEffort?: "high" | "low" | "medium",
+    temperatureDeprecated?: boolean,
+    requiresAdaptiveThinking?: boolean,
   ): void {
     if (extendedThinkingEnabled) {
-      // Extended thinking requires temperature 1.0
-      requestInput.inferenceConfig!.temperature = 1;
+      // Extended thinking normally requires temperature 1.0, but Claude Opus 4.7
+      // rejects any `temperature` parameter. For all other models, force 1.0.
+      if (!temperatureDeprecated) {
+        requestInput.inferenceConfig!.temperature = 1;
+      }
 
-      // Add thinking configuration to additionalModelRequestFields
+      // CLI-verified: Claude Opus 4.7 rejects thinking.type="enabled" and
+      // requires thinking.type="adaptive" (with no budget_tokens). All other
+      // Claude models still use enabled+budget.
+      const thinkingField: { budget_tokens?: number; type: "adaptive" | "enabled" } =
+        requiresAdaptiveThinking
+          ? { type: "adaptive" }
+          : { budget_tokens: budgetTokens, type: "enabled" };
+
       requestInput.additionalModelRequestFields = {
-        thinking: {
-          budget_tokens: budgetTokens,
-          type: "enabled",
-        },
+        thinking: thinkingField,
         ...(betaHeaders.length > 0 ? { anthropic_beta: betaHeaders } : {}),
         // Add thinking effort for Claude Opus 4.5 and Sonnet 4.6 (controls token expenditure)
         ...(thinkingEffort ? { output_config: { effort: thinkingEffort } } : {}),
@@ -1021,12 +1040,13 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
       logger.debug("[Bedrock Model Provider] Extended thinking enabled", {
         anthropicBeta: betaHeaders.length > 0 ? betaHeaders : undefined,
-        budgetTokens,
+        budgetTokens: requiresAdaptiveThinking ? "(adaptive)" : budgetTokens,
         interleavedThinking: betaHeaders.includes("interleaved-thinking-2025-05-14"),
         modelId,
         supports1MContext: betaHeaders.includes("context-1m-2025-08-07"),
-        temperature: 1,
+        temperature: temperatureDeprecated ? "(omitted)" : 1,
         thinkingEffort: thinkingEffort ?? "(not applicable)",
+        thinkingType: requiresAdaptiveThinking ? "adaptive" : "enabled",
       });
       return;
     }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -216,25 +216,32 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             const maxOutput = limits.maxOutputTokens;
             const vision = m.inputModalities.includes(ModelModality.IMAGE);
 
-            // Determine tooltip suffix based on inference profile type
-            let tooltipSuffix = "";
-            if (hasInferenceProfile) {
-              tooltipSuffix = modelIdToUse.startsWith("global.")
-                ? " (Global Inference Profile)"
-                : " (Regional Inference Profile)";
-            }
+            // Classify the invocation route so the tooltip can state it plainly.
+            const route = hasInferenceProfile
+              ? modelIdToUse.startsWith("global.")
+                ? "Global inference profile"
+                : "Local/regional inference profile"
+              : "Direct foundation model";
 
             const modelInfo: LanguageModelChatInformation = {
               capabilities: {
                 imageInput: vision,
                 toolCalling: true,
               },
+              detail: this.formatDetail(modelIdToUse, maxInput, maxOutput, vision),
               family: "bedrock",
               id: modelIdToUse,
               maxInputTokens: maxInput,
               maxOutputTokens: maxOutput,
               name: m.modelName,
-              tooltip: `Amazon Bedrock - ${m.providerName}${tooltipSuffix}`,
+              tooltip: this.formatTooltip({
+                maxInput,
+                maxOutput,
+                modelId: modelIdToUse,
+                providerName: m.providerName,
+                route,
+                vision,
+              }),
               version: "1.0.0",
             };
             infos.push(modelInfo);
@@ -269,12 +276,20 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
                 imageInput: vision,
                 toolCalling: true,
               },
+              detail: this.formatDetail(modelIdForLimits, maxInput, maxOutput, vision),
               family: "bedrock",
               id: profile.modelArn,
               maxInputTokens: maxInput,
               maxOutputTokens: maxOutput,
               name: profile.modelName,
-              tooltip: `Amazon Bedrock - ${profile.providerName} (Application Inference Profile)`,
+              tooltip: this.formatTooltip({
+                maxInput,
+                maxOutput,
+                modelId: modelIdForLimits,
+                providerName: profile.providerName,
+                route: "Application inference profile",
+                vision,
+              }),
               version: "1.0.0",
             };
             infos.push(profileInfo);
@@ -791,6 +806,80 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   }
 
   /**
+   * Build the inline detail string shown next to the model name in the picker.
+   * Format: "<context> ctx · <output>K out · <thinking-mode> · <vision>".
+   * The model ID is used only to consult getModelProfile for capability flags;
+   * display-side values (context and output) are the effective numeric limits.
+   */
+  private formatDetail(
+    modelId: string,
+    maxInput: number,
+    maxOutput: number,
+    vision: boolean,
+  ): string {
+    const profile = getModelProfile(modelId);
+    const ctxK = Math.round((maxInput + maxOutput) / 1000);
+    const outK = Math.round(maxOutput / 1000);
+    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M` : `${ctxK}K`;
+    const parts = [`${ctxLabel} ctx`, `${outK}K out`];
+
+    if (profile.requiresAdaptiveThinking) {
+      parts.push("adaptive thinking");
+    } else if (profile.supportsThinkingEffort) {
+      parts.push("adaptive or budget thinking");
+    } else if (profile.supportsThinking) {
+      parts.push("budget thinking");
+    }
+
+    if (vision) parts.push("vision");
+
+    return parts.join(" \u00B7 ");
+  }
+
+  /**
+   * Build a multi-line tooltip describing the model's capabilities and the
+   * Bedrock invocation route (direct model, regional/global inference profile,
+   * application inference profile, or manual entry). The route is surfaced so
+   * users can distinguish between, e.g., `us.anthropic.claude-opus-4-7` vs
+   * `global.anthropic.claude-opus-4-7` vs the base foundation model.
+   */
+  private formatTooltip(args: {
+    maxInput: number;
+    maxOutput: number;
+    modelId: string;
+    providerName: string;
+    route: string;
+    vision: boolean;
+  }): string {
+    const profile = getModelProfile(args.modelId);
+    const lines: string[] = [`Amazon Bedrock - ${args.providerName}`];
+    lines.push(`Route: ${args.route}`);
+    lines.push(`Model ID: ${args.modelId}`);
+
+    const ctxK = Math.round((args.maxInput + args.maxOutput) / 1000);
+    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M tokens` : `${ctxK}K tokens`;
+    lines.push(`Context: ${ctxLabel} | Max output: ${Math.round(args.maxOutput / 1000)}K tokens`);
+
+    if (profile.requiresAdaptiveThinking) {
+      lines.push("Thinking: adaptive only (uses output_config.effort)");
+    } else if (profile.supportsThinkingEffort) {
+      lines.push("Thinking: adaptive (recommended) or enabled+budget");
+    } else if (profile.supportsThinking) {
+      lines.push("Thinking: enabled+budget_tokens");
+    }
+
+    if (profile.temperatureDeprecated) {
+      lines.push("Note: temperature parameter is not supported");
+    }
+
+    if (args.vision) {
+      lines.push("Vision: image input supported");
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
    * Allow users with restricted permissions to manually supply a model or inference profile ID.
    */
   private async buildManualModelInformation(
@@ -823,12 +912,25 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           imageInput: likelyVisionCapable,
           toolCalling: true,
         },
+        detail: this.formatDetail(
+          baseModelId,
+          limits.maxInputTokens,
+          limits.maxOutputTokens,
+          likelyVisionCapable,
+        ),
         family: "bedrock",
         id: modelId,
         maxInputTokens: limits.maxInputTokens,
         maxOutputTokens: limits.maxOutputTokens,
         name: modelId,
-        tooltip: "Amazon Bedrock - manual model entry",
+        tooltip: this.formatTooltip({
+          maxInput: limits.maxInputTokens,
+          maxOutput: limits.maxOutputTokens,
+          modelId: baseModelId,
+          providerName: "Bedrock",
+          route: "Manual entry",
+          vision: likelyVisionCapable,
+        }),
         version: "1.0.0",
       };
     } catch (error) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -132,8 +132,7 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
   const validReasoningEffortValues: ReasoningEffort[] = ["high", "low", "medium", "minimal"];
   const rawReasoningEffort = config.get<string>("reasoningEffort");
   const reasoningEffort: ReasoningEffort | undefined =
-    rawReasoningEffort &&
-    validReasoningEffortValues.includes(rawReasoningEffort as ReasoningEffort)
+    rawReasoningEffort && validReasoningEffortValues.includes(rawReasoningEffort as ReasoningEffort)
       ? (rawReasoningEffort as ReasoningEffort)
       : undefined;
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -23,6 +23,7 @@ export interface BedrockSettings {
   promptCaching: {
     enabled: boolean;
   };
+  reasoningEffort: ReasoningEffort | undefined;
   region: string;
   thinking: {
     budgetTokens: number;
@@ -30,6 +31,18 @@ export interface BedrockSettings {
     enabled: boolean;
   };
 }
+
+/**
+ * Reasoning effort level for non-Anthropic models that accept the OpenAI-style
+ * `reasoning_effort` additional model request field (OpenAI gpt-oss and any
+ * other models whose profile sets `supportsReasoningEffort`).
+ *
+ * - `minimal`: OpenAI gpt-oss only (fastest, lowest cost). For other models
+ *   this is clamped to `low` at the call site.
+ * - `low` / `medium` / `high`: universally accepted.
+ * - `undefined`: do not send the parameter at all (default).
+ */
+export type ReasoningEffort = "high" | "low" | "medium" | "minimal";
 
 /**
  * Thinking effort level for Claude Opus 4.5 and Sonnet 4.6.
@@ -113,6 +126,17 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
       ? (rawEffort as ThinkingEffort)
       : "high";
 
+  // Read reasoning effort for non-Anthropic models (OpenAI gpt-oss style
+  // `reasoning_effort` parameter). Default is `undefined` -- the parameter is
+  // only sent when the user explicitly opts in.
+  const validReasoningEffortValues: ReasoningEffort[] = ["high", "low", "medium", "minimal"];
+  const rawReasoningEffort = config.get<string>("reasoningEffort");
+  const reasoningEffort: ReasoningEffort | undefined =
+    rawReasoningEffort &&
+    validReasoningEffortValues.includes(rawReasoningEffort as ReasoningEffort)
+      ? (rawReasoningEffort as ReasoningEffort)
+      : undefined;
+
   return {
     context1M: {
       enabled: context1MEnabled,
@@ -125,6 +149,7 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
     promptCaching: {
       enabled: promptCachingEnabled,
     },
+    reasoningEffort,
     region,
     thinking: {
       budgetTokens: Math.max(1024, thinkingBudgetTokens), // Ensure minimum 1024

--- a/src/stream-processor.ts
+++ b/src/stream-processor.ts
@@ -105,6 +105,26 @@ export class StreamProcessor {
         state.hasEmittedContent = true;
       }
 
+      // tool_use stop reason with no emitted content means the model tried to
+      // call a tool but the tool call failed to parse (common with models like
+      // GPT OSS that produce malformed tool JSON). Emit a fallback message so
+      // Copilot Chat surfaces something rather than leaving the turn silent.
+      if (
+        !state.hasEmittedContent &&
+        !token.isCancellationRequested &&
+        state.stopReason === StopReason.TOOL_USE
+      ) {
+        logger.warn(
+          "[Stream Processor] Model returned tool_use but no content was emitted (tool call may have failed to parse)",
+        );
+        progress.report(
+          new vscode.LanguageModelTextPart(
+            "*(The model attempted a tool call but the response could not be processed. This model may have limited tool calling support. Please try again or use a different model.)*",
+          ),
+        );
+        state.hasEmittedContent = true;
+      }
+
       this.logCompletion(state);
       this.validateStreamResult(state, token);
 
@@ -444,6 +464,15 @@ export class StreamProcessor {
     // rendered the reasoning to the user and the stream completed normally.
     // Require END_TURN so truncated/malformed streams aren't treated as successful.
     if (state.hasEmittedThinking && state.stopReason === StopReason.END_TURN) {
+      return;
+    }
+
+    // tool_use stop reason with no emitted content means the model responded
+    // with only a tool call that failed to parse (e.g., invalid JSON from
+    // models like GPT OSS). Don't throw -- the fallback message in
+    // processStream covers the user-visible case, and throwing here would
+    // surface a less helpful "No response content was generated" error.
+    if (state.stopReason === StopReason.TOOL_USE) {
       return;
     }
 

--- a/src/test/aws-integration.ts
+++ b/src/test/aws-integration.ts
@@ -1,0 +1,3 @@
+export function shouldRunAwsIntegrationTests(): boolean {
+  return process.env.RUN_AWS_INTEGRATION_TESTS === "1";
+}

--- a/src/test/bedrock-client.integration.test.ts
+++ b/src/test/bedrock-client.integration.test.ts
@@ -3,6 +3,7 @@ import * as assert from "node:assert";
 import { ModelModality } from "@aws-sdk/client-bedrock";
 
 import { BedrockAPIClient } from "../bedrock-client";
+import { shouldRunAwsIntegrationTests } from "./aws-integration";
 
 /**
  * Integration tests for BedrockAPIClient
@@ -16,7 +17,7 @@ import { BedrockAPIClient } from "../bedrock-client";
  * - Network access to Amazon Bedrock API endpoints
  *
  * To run these tests:
- *   npm run test
+ *   RUN_AWS_INTEGRATION_TESTS=1 bun run test
  *
  * To skip these tests if credentials aren't configured, they will be marked as skipped.
  */
@@ -25,7 +26,11 @@ suite("BedrockAPIClient Integration Tests", () => {
   const TEST_REGION = "us-east-1";
   let client: BedrockAPIClient;
 
-  setup(() => {
+  setup(function () {
+    if (!shouldRunAwsIntegrationTests()) {
+      this.skip();
+    }
+
     client = new BedrockAPIClient(TEST_REGION);
   });
 

--- a/src/test/bedrock-client.test.ts
+++ b/src/test/bedrock-client.test.ts
@@ -1,0 +1,124 @@
+import * as assert from "node:assert";
+
+import { BedrockAPIClient } from "../bedrock-client";
+
+interface BedrockAPIClientInternals {
+  bedrockClient: MockSendClient;
+  bedrockRuntimeClient: MockSendClient;
+  inferenceProfileCache: Map<string, string>;
+  unsupportedCountTokensModels: Set<string>;
+}
+
+interface MockSendClient {
+  send: (command: unknown, options?: unknown) => Promise<unknown>;
+}
+
+const countTokensInput = {} as Parameters<BedrockAPIClient["countTokens"]>[1];
+
+function awsError(name: string, message: string, httpStatusCode?: number): Error {
+  const error = new Error(message) as Error & { $metadata?: { httpStatusCode: number } };
+  error.name = name;
+  if (httpStatusCode) {
+    error.$metadata = { httpStatusCode };
+  }
+  return error;
+}
+
+function internals(client: BedrockAPIClient): BedrockAPIClientInternals {
+  return client as unknown as BedrockAPIClientInternals;
+}
+
+suite("BedrockAPIClient unit tests", () => {
+  suite("CountTokens unsupported cache", () => {
+    test("does not cache transient CountTokens failures", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let countTokensCalls = 0;
+
+      state.bedrockRuntimeClient = {
+        send: async () => {
+          countTokensCalls += 1;
+          throw awsError("ThrottlingException", "Rate exceeded");
+        },
+      };
+
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+
+      assert.equal(countTokensCalls, 2);
+      assert.equal(state.unsupportedCountTokensModels.has("openai.gpt-oss-120b-1:0"), false);
+    });
+
+    test("caches deterministic CountTokens unsupported failures", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let countTokensCalls = 0;
+
+      state.bedrockRuntimeClient = {
+        send: async () => {
+          countTokensCalls += 1;
+          throw awsError("ResourceNotFoundException", "Model does not support CountTokens", 404);
+        },
+      };
+
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+
+      assert.equal(countTokensCalls, 1);
+      assert.equal(state.unsupportedCountTokensModels.has("openai.gpt-oss-120b-1:0"), true);
+    });
+
+    test("clears CountTokens unsupported cache when clients are recreated", () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      state.unsupportedCountTokensModels.add("openai.gpt-oss-120b-1:0");
+
+      client.setRegion("us-west-2");
+
+      assert.equal(state.unsupportedCountTokensModels.size, 0);
+    });
+  });
+
+  suite("inference profile negative cache", () => {
+    test("does not cache aborted profile lookups", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let lookupCalls = 0;
+
+      state.bedrockClient = {
+        send: async () => {
+          lookupCalls += 1;
+          throw awsError("AbortError", "Operation aborted");
+        },
+      };
+
+      await client.resolveModelId("global.openai.gpt-oss-120b-1:0");
+      await client.resolveModelId("global.openai.gpt-oss-120b-1:0");
+
+      assert.equal(lookupCalls, 2);
+      assert.equal(state.inferenceProfileCache.has("global.openai.gpt-oss-120b-1:0"), false);
+    });
+
+    test("caches definite profile misses", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let lookupCalls = 0;
+
+      state.bedrockClient = {
+        send: async () => {
+          lookupCalls += 1;
+          throw awsError("ResourceNotFoundException", "Profile not found", 404);
+        },
+      };
+
+      await client.resolveModelId("global.openai.gpt-oss-120b-1:0");
+      await client.resolveModelId("global.openai.gpt-oss-120b-1:0");
+
+      assert.equal(lookupCalls, 1);
+      assert.equal(
+        state.inferenceProfileCache.get("global.openai.gpt-oss-120b-1:0"),
+        "global.openai.gpt-oss-120b-1:0",
+      );
+    });
+  });
+});

--- a/src/test/bedrock-client.test.ts
+++ b/src/test/bedrock-client.test.ts
@@ -132,6 +132,31 @@ suite("BedrockAPIClient unit tests", () => {
   });
 
   suite("inference profile negative cache", () => {
+    test("resolves apac dotted inference profiles", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let lookupCalls = 0;
+
+      state.bedrockClient = {
+        send: async () => {
+          lookupCalls += 1;
+          return {
+            models: [
+              {
+                modelArn:
+                  "arn:aws:bedrock:ap-southeast-1::foundation-model/anthropic.claude-3-sonnet:0",
+              },
+            ],
+          };
+        },
+      };
+
+      const resolvedModelId = await client.resolveModelId("apac.anthropic.claude-3-sonnet:0");
+
+      assert.equal(lookupCalls, 1);
+      assert.equal(resolvedModelId, "anthropic.claude-3-sonnet:0");
+    });
+
     test("does not cache aborted profile lookups", async () => {
       const client = new BedrockAPIClient("us-east-1");
       const state = internals(client);

--- a/src/test/bedrock-client.test.ts
+++ b/src/test/bedrock-client.test.ts
@@ -15,11 +15,22 @@ interface MockSendClient {
 
 const countTokensInput = {} as Parameters<BedrockAPIClient["countTokens"]>[1];
 
-function awsError(name: string, message: string, httpStatusCode?: number): Error {
-  const error = new Error(message) as Error & { $metadata?: { httpStatusCode: number } };
+function awsError(
+  name: string,
+  message: string,
+  httpStatusCode?: number,
+  responseStatusCode?: number,
+): Error {
+  const error = new Error(message) as Error & {
+    $metadata?: { httpStatusCode: number };
+    $response?: { statusCode: number };
+  };
   error.name = name;
   if (httpStatusCode) {
     error.$metadata = { httpStatusCode };
+  }
+  if (responseStatusCode) {
+    error.$response = { statusCode: responseStatusCode };
   }
   return error;
 }
@@ -58,6 +69,47 @@ suite("BedrockAPIClient unit tests", () => {
         send: async () => {
           countTokensCalls += 1;
           throw awsError("ResourceNotFoundException", "Model does not support CountTokens", 404);
+        },
+      };
+
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+
+      assert.equal(countTokensCalls, 1);
+      assert.equal(state.unsupportedCountTokensModels.has("openai.gpt-oss-120b-1:0"), true);
+    });
+
+    test("caches current CountTokens unsupported validation messages", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let countTokensCalls = 0;
+
+      state.bedrockRuntimeClient = {
+        send: async () => {
+          countTokensCalls += 1;
+          throw awsError(
+            "ValidationException",
+            "CountTokens API does not currently support this model.",
+          );
+        },
+      };
+
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+      await client.countTokens("openai.gpt-oss-120b-1:0", countTokensInput);
+
+      assert.equal(countTokensCalls, 1);
+      assert.equal(state.unsupportedCountTokensModels.has("openai.gpt-oss-120b-1:0"), true);
+    });
+
+    test("caches structured not-found CountTokens responses", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      let countTokensCalls = 0;
+
+      state.bedrockRuntimeClient = {
+        send: async () => {
+          countTokensCalls += 1;
+          throw awsError("ValidationException", "Model lookup failed", undefined, 404);
         },
       };
 

--- a/src/test/manage-settings.integration.test.ts
+++ b/src/test/manage-settings.integration.test.ts
@@ -1,6 +1,7 @@
 import * as assert from "node:assert";
 
 import { getBedrockRegionsFromSSM } from "../commands/manage-settings";
+import { shouldRunAwsIntegrationTests } from "./aws-integration";
 
 /**
  * Integration tests for manage-settings.ts
@@ -14,10 +15,16 @@ import { getBedrockRegionsFromSSM } from "../commands/manage-settings";
  * - IAM permissions for ssm:GetParametersByPath
  *
  * To run these tests:
- *   bun run test
+ *   RUN_AWS_INTEGRATION_TESTS=1 bun run test
  */
 
 suite("getBedrockRegionsFromSSM Integration Tests", () => {
+  setup(function () {
+    if (!shouldRunAwsIntegrationTests()) {
+      this.skip();
+    }
+  });
+
   test("should fetch Bedrock regions from SSM Parameter Store", async function () {
     this.timeout(30_000); // Allow 30 seconds for AWS API call
 

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -125,7 +125,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       assert.ok(est > 0);
     });
 
-    test("does not add 1M context beta header for Opus 4.7", () => {
+    test("does not add legacy opt-in beta headers for Opus 4.7", () => {
       const provider = providerInternals(
         new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
       );
@@ -140,8 +140,25 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       );
 
       assert.equal(betaHeaders.includes("context-1m-2025-08-07"), false);
-      assert.equal(betaHeaders.includes("interleaved-thinking-2025-05-14"), true);
+      assert.equal(betaHeaders.includes("interleaved-thinking-2025-05-14"), false);
       assert.equal(betaHeaders.includes("effort-2025-11-24"), true);
+    });
+
+    test("adds interleaved thinking beta header for Opus 4.6", () => {
+      const provider = providerInternals(
+        new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
+      );
+      const modelId = "anthropic.claude-opus-4-6-v1";
+
+      const betaHeaders = provider.buildBetaHeaders(
+        getModelProfile(modelId),
+        modelId,
+        true,
+        false,
+        false,
+      );
+
+      assert.equal(betaHeaders.includes("interleaved-thinking-2025-05-14"), true);
     });
 
     test("adds 1M context beta header for models that require opt-in", () => {

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -4,8 +4,38 @@ import * as vscode from "vscode";
 import { convertMessages, stripThinkingContent } from "../converters/messages";
 import { convertTools } from "../converters/tools";
 import { logger } from "../logger";
+import { getModelProfile } from "../profiles";
 import { BedrockChatModelProvider } from "../provider";
 import type { BedrockModelSummary } from "../types";
+
+interface ProviderInternals {
+  applyReasoningEffort: (
+    requestInput: { additionalModelRequestFields?: Record<string, unknown> },
+    modelId: string,
+    baseModelId: string,
+    reasoningEffort: "high" | "low" | "medium" | "minimal",
+  ) => void;
+  buildBetaHeaders: (
+    modelProfile: ReturnType<typeof getModelProfile>,
+    modelId: string,
+    extendedThinkingEnabled: boolean,
+    context1MEnabled: boolean,
+    thinkingEffortEnabled: boolean,
+  ) => string[];
+  formatDetail: (modelId: string, maxInput: number, maxOutput: number, vision: boolean) => string;
+  formatTooltip: (args: {
+    maxInput: number;
+    maxOutput: number;
+    modelId: string;
+    providerName: string;
+    route: string;
+    vision: boolean;
+  }) => string;
+}
+
+function providerInternals(provider: BedrockChatModelProvider): ProviderInternals {
+  return provider as unknown as ProviderInternals;
+}
 
 // Mock implementations extracted to avoid function nesting depth issues
 const mockSecretStorage = {
@@ -93,6 +123,96 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       );
       assert.equal(typeof est, "number");
       assert.ok(est > 0);
+    });
+
+    test("does not add 1M context beta header for Opus 4.7", () => {
+      const provider = providerInternals(
+        new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
+      );
+      const modelId = "anthropic.claude-opus-4-7-20260420-v1:0";
+
+      const betaHeaders = provider.buildBetaHeaders(
+        getModelProfile(modelId),
+        modelId,
+        true,
+        true,
+        true,
+      );
+
+      assert.equal(betaHeaders.includes("context-1m-2025-08-07"), false);
+      assert.equal(betaHeaders.includes("interleaved-thinking-2025-05-14"), true);
+      assert.equal(betaHeaders.includes("effort-2025-11-24"), true);
+    });
+
+    test("adds 1M context beta header for models that require opt-in", () => {
+      const provider = providerInternals(
+        new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
+      );
+      const modelId = "global.anthropic.claude-opus-4-6-20251124-v1:0";
+
+      const betaHeaders = provider.buildBetaHeaders(
+        getModelProfile(modelId),
+        modelId,
+        false,
+        true,
+        false,
+      );
+
+      assert.deepStrictEqual(betaHeaders, ["context-1m-2025-08-07"]);
+    });
+
+    test("keeps minimal reasoning effort for routed OpenAI models", () => {
+      const provider = providerInternals(
+        new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
+      );
+      const requestInput: { additionalModelRequestFields?: Record<string, unknown> } = {};
+
+      provider.applyReasoningEffort(
+        requestInput,
+        "global.openai.gpt-oss-120b-1:0",
+        "openai.gpt-oss-120b-1:0",
+        "minimal",
+      );
+
+      assert.equal(requestInput.additionalModelRequestFields?.reasoning_effort, "minimal");
+    });
+
+    test("downgrades minimal reasoning effort for non-OpenAI models", () => {
+      const provider = providerInternals(
+        new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
+      );
+      const requestInput: { additionalModelRequestFields?: Record<string, unknown> } = {};
+
+      provider.applyReasoningEffort(
+        requestInput,
+        "global.qwen.qwen3-coder-480b-a35b-v1:0",
+        "qwen.qwen3-coder-480b-a35b-v1:0",
+        "minimal",
+      );
+
+      assert.equal(requestInput.additionalModelRequestFields?.reasoning_effort, "low");
+    });
+
+    test("labels non-adaptive effort-capable Claude models as budget thinking", () => {
+      const provider = providerInternals(
+        new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
+      );
+      const modelId = "anthropic.claude-opus-4-6-20251124-v1:0";
+
+      const detail = provider.formatDetail(modelId, 872_000, 128_000, false);
+      const tooltip = provider.formatTooltip({
+        maxInput: 872_000,
+        maxOutput: 128_000,
+        modelId,
+        providerName: "Anthropic",
+        route: "Direct foundation model",
+        vision: false,
+      });
+
+      assert.match(detail, /budget thinking/);
+      assert.doesNotMatch(detail, /adaptive/);
+      assert.match(tooltip, /enabled\+budget_tokens/);
+      assert.doesNotMatch(tooltip, /adaptive/);
     });
   });
 

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -148,7 +148,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const provider = providerInternals(
         new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
       );
-      const modelId = "global.anthropic.claude-opus-4-6-20251124-v1:0";
+      const modelId = "global.anthropic.claude-opus-4-6-v1";
 
       const betaHeaders = provider.buildBetaHeaders(
         getModelProfile(modelId),
@@ -197,7 +197,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const provider = providerInternals(
         new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
       );
-      const modelId = "anthropic.claude-opus-4-6-20251124-v1:0";
+      const modelId = "anthropic.claude-opus-4-6-v1";
 
       const detail = provider.formatDetail(modelId, 872_000, 128_000, false);
       const tooltip = provider.formatTooltip({


### PR DESCRIPTION
Hi! Thanks for the nudge on the issue — here's the branch.

This PR bundles 9 focused, individually-reviewable commits that have been running in production in my fork (`rangan2510/aws-bedrock-for-copilot`, the friendly fork I mentioned in the issue). Each commit is self-contained and ordered by risk, with the safest mechanical fixes first and the larger capability/UX additions last. **Cherry-picking any subset is intended and supported** — there are no hidden cross-commit dependencies beyond what's stated below.

Every change is CLI-verified against the live Bedrock Converse API in `us-east-1` (and `us-west-2` where relevant). No fork-specific rebranding, vendor renames, or config-namespace changes are in this PR — the `aws-bedrock-for-copilot` identity changes that let my fork coexist with this extension stay in the fork.

I've run `bunx tsgo --noEmit` and `bunx eslint -f compact` on every commit individually; both are clean. The only ESLint warnings that show up are pre-existing `require-description` warnings in `src/test/provider.test.ts` which I did not touch.

---

### Commits (in merge order)

| # | Hash | Area | Size |
|---|---|---|---|
| 1 | `d437b79` | `fix: stop GLM 5 (zai.*) being treated as inference profile` | bedrock-client.ts, provider.ts (+14 / −6) |
| 2 | `fd3998a` | `fix: cache CountTokens unsupported-model responses` | bedrock-client.ts (+40 / −4) |
| 3 | `dd8687a` | `feat: support Claude Opus 4.7 adaptive thinking and deprecated temperature` | profiles.ts, provider.ts (+67 / −14) |
| 4 | `e596214` | `feat: enable extended thinking for Claude Haiku 4.5` | profiles.ts (+5 / −2) |
| 5 | `c5fa3e5` | `feat: graceful tool_use fallback for unparseable tool JSON` | stream-processor.ts (+29) |
| 6 | `92f70c9` | `fix: correct Claude token/context limits per Anthropic docs` | profiles.ts (+30 / −4) |
| 7 | `2bcdae2` | `feat: support OpenAI-style reasoning_effort for non-Anthropic models` | profiles.ts, settings.ts, provider.ts, package.json (+92 / −2) |
| 8 | `bb7a2c4` | `feat: show capability detail and invocation route in model picker` | provider.ts (+112 / −10) |
| 9 | `4c48f81` | `feat: expand provider capability profiles (80+ models across 14 providers)` | profiles.ts, provider.ts (+252 / −159) |

Commits 1–6 are pure fixes / model-data corrections; commits 7–9 are additive features. Happy to split this into 9 separate PRs if that's easier to merge — just say the word and I'll open them. Keeping it as one branch for now so you can see the shape.

---

### 1. `fix: stop GLM 5 (zai.*) being treated as inference profile`

`resolveModelId` matched `zai.glm-5` against the permissive `[a-z]{2,3}\.` pattern and treated it as a cross-region inference profile, sending every `provideTokenCount` call into a `GetInferenceProfile → 404 → retry` loop. Copilot Chat issues many token-count calls per turn, so the user saw repeating "Resolved model ID" debug lines and never got a reply.

- Restrict the dot-prefix pattern to the known AWS region prefixes (`us|eu|ap|ca|sa|me|af|il|cn|global`). `zai` (and any future three-letter vendor) no longer false-matches.
- Cache the negative result of `GetInferenceProfile` so a real prefix that fails once doesn't keep retrying.
- Downgrade the per-call "Resolved model ID" log to `trace`.

### 2. `fix: cache CountTokens unsupported-model responses`

Bedrock's `CountTokens` API is not supported for some models and inference profiles (notably the newer Opus variants via `global.anthropic.*`). Copilot Chat calls `provideTokenCount` many times per turn while assembling tool-heavy requests, so each call was issuing a fresh network request that was rejected, logging a debug line, and falling back to estimation. Results were correct but the accumulated latency stalled the chat UI on "Working" and flooded the logs.

- Cache the model ID (and its resolved base model) on the first failure so subsequent `provideTokenCount` calls short-circuit to estimation without touching the network.
- Don't cache cancellations — the user may retry later.
- Downgrade the per-call fallback log from `debug` to `trace`.

### 3. `feat: support Claude Opus 4.7 adaptive thinking and deprecated temperature`

Claude Opus 4.7 introduced two breaking API changes that the current code path does not handle:

- `thinking.type` must be `"adaptive"` (with no `budget_tokens`). The previous `thinking.type="enabled"` + `budget_tokens` payload returns a `ValidationException`.
- The `temperature` parameter is deprecated. Any request that includes `temperature` is rejected, including the `temperature=1` that extended thinking historically forced.

This change:
- Adds two `ModelProfile` flags — `requiresAdaptiveThinking` and `temperatureDeprecated` — both set only for `anthropic.claude-opus-4-7`. Other Claude models are untouched.
- Threads the flags through `buildRequestInput` and `configureAdditionalModelFields`. When `temperatureDeprecated`, `temperature` is omitted from `inferenceConfig` (in both the default path and the thinking path). When `requiresAdaptiveThinking`, `additionalModelRequestFields.thinking` becomes `{ type: "adaptive" }` with no `budget_tokens`.
- Also adds `opus-4-7` to `supportsThinkingEffort` detection so effort-aware flows treat it like Opus 4.6.

Verified end-to-end against `global.anthropic.claude-opus-4-7` in `us-east-1`.

### 4. `feat: enable extended thinking for Claude Haiku 4.5`

`supportsThinking` only matched `opus-4`, `sonnet-4`, and `sonnet-3.7`, so Haiku 4.5 was treated as non-thinking. Haiku 4.5 does support extended thinking via `thinking.type="enabled"` + `budget_tokens` (but not the effort parameter — matching Sonnet 4.5 / Opus 4.5 behaviour). Opts it in, nothing else.

### 5. `feat: graceful tool_use fallback for unparseable tool JSON`

Some Bedrock models (notably OpenAI gpt-oss, occasionally others) return `stopReason=tool_use` with no content block — the model tried to emit a tool call but the JSON was malformed. The previous code path threw `"No response content was generated. Stop reason: tool_use"` and surfaced as a hard error to Copilot Chat.

Two additive hunks to `stream-processor.ts`:
1. In the post-stream no-content check, recognise `StopReason.TOOL_USE` and report a helpful `LanguageModelTextPart` explaining the model attempted a tool call but the response could not be processed.
2. In `validateStreamResult`, early-return on `StopReason.TOOL_USE` so we never synthesise the confusing "No response content was generated" error for the same case.

### 6. `fix: correct Claude token/context limits per Anthropic docs`

Update `getClaudeTokenLimits` and `supports1MContext` to match published Anthropic limits:

- **Opus 4.7**: 1M context (always, no beta header needed), 128K max output.
- **Opus 4.5**: 200K / 64K (split out from the generic `opus-4` fallback).
- **Opus 4.1**: 200K / 32K (previously 64K; Anthropic's published limit is 32K).
- **Opus 4**: 200K / 32768 (same as above; previously 64K).
- `supports1MContext` now also returns true for `opus-4-7` so the beta-header logic knows 1M is supported (though Opus 4.7 doesn't require the `context-1m-*` header — 1M is its default).

Opus 4.6, Sonnet 4.6, Sonnet 4.x, Sonnet 3.7, Haiku 4.5, and older Haiku/Sonnet variants are unchanged.

Supersedes #566 

### 7. `feat: support OpenAI-style reasoning_effort for non-Anthropic models`

OpenAI gpt-oss on Bedrock exposes an OpenAI-style `reasoning_effort` parameter (`low | medium | high`, plus a gpt-oss-only `minimal`). There's no way to set it today, so users can't ask for deeper or shallower reasoning from gpt-oss.

- `profiles.ts`: add `ModelProfile.supportsReasoningEffort`. The OpenAI branch opts in here; other providers' opt-ins land in commit 9.
- `settings.ts`: add `ReasoningEffort` type and `BedrockSettings.reasoningEffort`. Default is `undefined` — the parameter is only sent when the user opts in.
- `package.json`: add `bedrock.reasoningEffort` contribution (`null | minimal | low | medium | high`) with enum descriptions.
- `provider.ts`: thread the value through `buildRequestInput` / `configureAdditionalModelFields`. The resolved value is merged into `additionalModelRequestFields.reasoning_effort` alongside any existing thinking/beta-header config. `minimal` is clamped to `low` for non-OpenAI models (CLI-verified that other providers reject `minimal`).

Anthropic Claude models are untouched — they continue to use `bedrock.thinking.*` exclusively. Fully backward-compatible: omit the setting and the parameter is never sent.

### 8. `feat: show capability detail and invocation route in model picker`

The picker currently shows only the model name plus a short `Amazon Bedrock - <provider>(...Inference Profile)` tooltip. Users can't tell at a glance:
- the context / output limits,
- whether the model supports thinking, and in what mode,
- whether Copilot is about to invoke the model directly, via a regional profile (`us.*` / `eu.*` / `ap.*`), via a global profile, or via an application inference profile ARN.

Given the same foundation model can appear under several routes (e.g. `anthropic.claude-opus-4-7` vs `us.anthropic.claude-opus-4-7` vs `global.anthropic.claude-opus-4-7`) this is surprisingly hard to inspect.

Adds two private helpers in `provider.ts`:
- `formatDetail(modelId, maxInput, maxOutput, vision)` → inline string like `"200K ctx · 128K out · budget thinking · vision"` for the new `LanguageModelChatInformation.detail` field.
- `formatTooltip({ providerName, modelId, maxInput, maxOutput, vision, route })` → multi-line tooltip with provider, the computed Route (`Direct foundation model` / `Local/regional inference profile` / `Global inference profile` / `Application inference profile` / `Manual entry`), resolved model ID, context/output limits, thinking capability, and a note when temperature is not supported.

All three existing build paths (foundation-model loop, application-profile loop, `buildManualModelInformation`) now set `detail` + `tooltip` via these helpers. No other behaviour changes — in particular, the existing LEGACY lifecycle filter in `bedrock-client.ts` is untouched. I kept that out of scope intentionally.

### 9. `feat: expand provider capability profiles (80+ models across 14 providers)`

`getModelProfile` currently only special-cases Amazon Nova, Anthropic Claude, Mistral, and OpenAI; every other provider falls through to `defaultProfile` with `supportsToolChoice: false`. This prevents Llama, Cohere, AI21, Qwen, DeepSeek, Kimi, GLM, MiniMax, NVIDIA Nemotron, Google Gemma, and Writer Palmyra models from working with any Copilot Chat feature that relies on tool calling — and all of these models do support tool calling on Bedrock.

CLI-verified (`aws bedrock-runtime converse`) for every provider as of 2026-04:

- **ai21 / cohere / google / meta / nvidia** (merged into one case): tool calling on, `reasoning_effort` silently ignored on these families so not advertised.
- **deepseek**: V3.2 gets tools + `reasoning_effort`; R1 is reasoning-only (rejects both), opted out.
- **minimax / moonshot / moonshotai / qwen / zai** (merged): tool calling on + `reasoning_effort` on — all produce `reasoningContent` and accept `low/medium/high`.
- **mistral**: modern models (Large 3, Pixtral, Magistral, Ministral 3, Devstral 2, Voxtral) now get `supportsToolChoice: true`. Legacy non-tool models (`mistral-7b-instruct`, `mixtral-8x7b-instruct`) opted out individually.
- **writer**: Palmyra X4/X5 get tool calling; Palmyra Vision 7B is vision-only and stays on `defaultProfile`.

Cases are reordered alphabetically to satisfy `perfectionist/sort-switch-case`, with identical-body cases merged for `sonarjs/no-duplicated-branches`.

`provider.ts` side-effects from this commit: `formatDetail` / `formatTooltip` restructured to drop mutating `array.push` chains; the route-classification ternary split into an if/else; and `configureAdditionalModelFields` split into `applyExtendedThinkingFields` / `applyReasoningEffort` helpers to bring cognitive complexity back under the SonarJS threshold of 20 after commit 7 added `reasoning_effort`. Dispatch tree and output are unchanged.

---

### What's intentionally NOT in this PR

- No rebranding / vendor renames / namespace changes. The `aws-bedrock-for-copilot` identity stays in my fork.
- No change to the LEGACY lifecycle filter in `bedrock-client.ts`. My fork surfaces LEGACY models in the picker with a warning glyph instead of filtering them; that's a policy choice for you to make. Happy to propose separately if you want.
- No expansion of `buildManualModelInformation`'s vision heuristic (my fork has a slightly larger regex). Orthogonal to this PR.
- No test additions. Every change was verified against the live API; happy to add unit tests for `formatDetail` / `formatTooltip` / the resolution logic in commit 1 if you'd prefer that before merge — just flag the files.

### Testing

- `bun install && bunx tsgo --noEmit` — clean.
- `bunx eslint -f compact src/**/*.ts` — only pre-existing `require-description` warnings in `src/test/provider.test.ts`, which I didn't touch.
- Manually verified end-to-end in VS Code against the following models in `us-east-1`:
  - `global.anthropic.claude-opus-4-7` (commits 3, 6, 8)
  - `us.anthropic.claude-haiku-4-5-20251001-v1:0` (commits 4, 6, 8)
  - `us.anthropic.claude-sonnet-4-6` (commits 6, 8)
  - `openai.gpt-oss-120b-1:0` (commits 5, 7)
  - `zai.glm-5` (commit 1)
  - Various Llama / Qwen / Gemma models through Copilot Chat `@workspace` (commit 9)

### If you want to merge a subset

All 9 commits are independent and ordered least-to-most-invasive. The only hard dependency is that commit 9 imports a helper method added in commit 7 (`applyReasoningEffort`), so if you want 9 you need 7. Everything else can be picked individually.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New bedrock.reasoningEffort setting to configure reasoning budgets; expanded model profiles for adaptive thinking, temperature deprecation, and reasoning-effort support; UI model picker shows enhanced capability notes.

* **Bug Fixes**
  * Fallback message for tool-use stop events to avoid empty replies; improved error classification to avoid inappropriate caching.

* **Performance**
  * Fewer redundant API calls via smarter caching and cache-clearing on region/client changes.

* **Tests**
  * Conditional AWS integration tests and new unit tests covering caching and profile behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->