### PR TITLE
[codex] fix Claude 4.7 fallback profile detection

### DIFF
--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -922,7 +922,7 @@ function createBearerTokenSigner(apiKey: string) {
 }
 
 function getClaude47GeoPrefix(region: string): string | undefined {
-  if (region.startsWith("us-") || region.startsWith("ca-")) {
+  if ((region.startsWith("us-") && !region.startsWith("us-gov-")) || region.startsWith("ca-")) {
     return "us";
   }
 

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -397,14 +397,15 @@ export class BedrockAPIClient {
 
     // Check if this looks like an inference profile
     // Patterns:
-    // - Regional/Global: starts with a valid Bedrock cross-region inference
-    //   profile prefix (us., eu., apac., global.)
+    // - Regional/Global: starts with a valid Bedrock cross-region inference profile prefix
+    //   (global., geography prefixes like us./eu./jp./au., or partition-specific prefixes)
     //   Restricted to known prefixes so we don't false-positive on vendor IDs
     //   like `zai.glm-5` (zai is 3 letters but is NOT an AWS region prefix).
     // - Application: starts with "ip-" (ip-...)
     // - ARN: full ARN format (arn:aws:bedrock:region:account:inference-profile/...
     //   or application-inference-profile/...)
-    const dotProfilePattern = /^(global|us|eu|apac)\./;
+    const dotProfilePattern =
+      /^(global|af|ap|apac|au|ca|cn-north|cn-northwest|eu|il|jp|me|mx|sa|us|us-gov-east|us-gov-west)\./;
     const arnProfilePattern =
       /^arn:aws(-[a-z0-9]+)?:bedrock:[a-z0-9-]+:\d{12}:(application-)?inference-profile\//;
     const appProfileIdPattern = /^ip-[a-z0-9]+/i;
@@ -522,6 +523,26 @@ export class BedrockAPIClient {
       globalProfileId: null | string;
       regionalProfileIds: string[];
     }[] = [
+      {
+        baseModelId: "anthropic.claude-opus-4-7",
+        displayName: "Claude Opus 4.7",
+        globalProfileId: hasGlobalProfiles ? "global.anthropic.claude-opus-4-7" : null,
+        regionalProfileIds: getClaude47RegionalProfileIds(
+          this.region,
+          regionPrefix,
+          "anthropic.claude-opus-4-7",
+        ),
+      },
+      {
+        baseModelId: "anthropic.claude-sonnet-4-7",
+        displayName: "Claude Sonnet 4.7",
+        globalProfileId: hasGlobalProfiles ? "global.anthropic.claude-sonnet-4-7" : null,
+        regionalProfileIds: getClaude47RegionalProfileIds(
+          this.region,
+          regionPrefix,
+          "anthropic.claude-sonnet-4-7",
+        ),
+      },
       {
         baseModelId: "anthropic.claude-opus-4-6-v1",
         displayName: "Claude Opus 4.6",
@@ -898,4 +919,40 @@ function createBearerTokenSigner(apiKey: string) {
       return request;
     },
   };
+}
+
+function getClaude47GeoPrefix(region: string): string | undefined {
+  if (region.startsWith("us-") || region.startsWith("ca-")) {
+    return "us";
+  }
+
+  if (region.startsWith("eu-")) {
+    return "eu";
+  }
+
+  if (region === "ap-northeast-1" || region === "ap-northeast-3") {
+    return "jp";
+  }
+
+  if (region === "ap-southeast-2" || region === "ap-southeast-4" || region === "ap-southeast-6") {
+    return "au";
+  }
+
+  return undefined;
+}
+
+function getClaude47RegionalProfileIds(
+  region: string,
+  defaultRegionPrefix: string,
+  baseModelId: string,
+): string[] {
+  const prefixes = new Set<string>();
+  const geoPrefix = getClaude47GeoPrefix(region);
+
+  if (geoPrefix) {
+    prefixes.add(geoPrefix);
+  }
+  prefixes.add(defaultRegionPrefix);
+
+  return [...prefixes].map((prefix) => `${prefix}.${baseModelId}`);
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -984,14 +984,18 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // By default, prefer global inference profiles for best availability, then regional, then base model
       // When preferRegional is enabled, check regional profiles first (for Control Tower compliance)
       const globalProfileId = `global.${m.modelId}`;
-      const regionalProfileId = `${regionPrefix}.${m.modelId}`;
+      const regionalProfileId = this.findRegionalProfileId(
+        m.modelId,
+        availableProfileIds,
+        regionPrefix,
+      );
 
       let modelIdToUse = m.modelId;
       let hasInferenceProfile = false;
 
       if (preferRegional) {
         // Prefer regional profiles first
-        if (availableProfileIds.has(regionalProfileId)) {
+        if (regionalProfileId) {
           modelIdToUse = regionalProfileId;
           hasInferenceProfile = true;
           logger.trace(
@@ -1010,7 +1014,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           modelIdToUse = globalProfileId;
           hasInferenceProfile = true;
           logger.trace(`[Bedrock Model Provider] Using global inference profile for ${m.modelId}`);
-        } else if (availableProfileIds.has(regionalProfileId)) {
+        } else if (regionalProfileId) {
           modelIdToUse = regionalProfileId;
           hasInferenceProfile = true;
           logger.trace(
@@ -1368,8 +1372,13 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
     // If this was a global profile, try regional
     if (candidate.modelIdToUse.startsWith("global.")) {
-      const regionalProfileId = `${regionPrefix}.${candidate.model.modelId}`;
-      if (availableProfileIds.has(regionalProfileId)) {
+      const regionalProfileId = this.findRegionalProfileId(
+        candidate.model.modelId,
+        availableProfileIds,
+        regionPrefix,
+        new Set([candidate.modelIdToUse]),
+      );
+      if (regionalProfileId) {
         // Profile is in ListInferenceProfiles, trust it
         logger.info(
           `[Bedrock Model Provider] Using regional profile ${regionalProfileId} instead of global profile`,
@@ -1381,7 +1390,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           modelIdToUse: regionalProfileId,
         };
       }
-    } else if (candidate.modelIdToUse.startsWith(`${regionPrefix}.`)) {
+    } else if (this.isRegionalProfileForModel(candidate.modelIdToUse, candidate.model.modelId)) {
       // If this was a regional profile and preferRegional=true, skip global fallback
       // (honors user preference for regional-only in Control Tower/SCP environments)
       if (preferRegional) {
@@ -1426,6 +1435,28 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       `[Bedrock Model Provider] No accessible inference profile or base model for ${candidate.model.modelId}`,
     );
     return { ...candidate, isAccessible: false };
+  }
+
+  private findRegionalProfileId(
+    modelId: string,
+    availableProfileIds: Set<string>,
+    regionPrefix: string,
+    excludedProfileIds = new Set<string>(),
+  ): string | undefined {
+    const preferredProfileId = `${regionPrefix}.${modelId}`;
+    if (
+      availableProfileIds.has(preferredProfileId) &&
+      !excludedProfileIds.has(preferredProfileId)
+    ) {
+      return preferredProfileId;
+    }
+
+    return [...availableProfileIds]
+      .filter(
+        (profileId) =>
+          !excludedProfileIds.has(profileId) && this.isRegionalProfileForModel(profileId, modelId),
+      )
+      .toSorted()[0];
   }
 
   /**
@@ -1564,6 +1595,10 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     return undefined;
+  }
+
+  private isRegionalProfileForModel(profileId: string, modelId: string): boolean {
+    return !profileId.startsWith("global.") && profileId.endsWith(`.${modelId}`);
   }
 
   /**

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -172,6 +172,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             availableProfileIds,
             regionPrefix,
             settings.inferenceProfiles.preferRegional,
+            settings.region,
           );
 
           progress?.report({
@@ -187,6 +188,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
                 availableProfileIds,
                 settings.inferenceProfiles.preferRegional,
                 abortController.signal,
+                settings.region,
               ),
             ),
           );
@@ -964,6 +966,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     availableProfileIds: Set<string>,
     regionPrefix: string,
     preferRegional = false,
+    sourceRegion?: string,
   ): {
     hasInferenceProfile: boolean;
     model: BedrockModelSummary;
@@ -988,6 +991,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         m.modelId,
         availableProfileIds,
         regionPrefix,
+        this.getRegionalProfilePriorityPrefixes(regionPrefix, sourceRegion),
       );
 
       let modelIdToUse = m.modelId;
@@ -1299,6 +1303,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     availableProfileIds: Set<string>,
     preferRegional: boolean,
     abortSignal: AbortSignal,
+    sourceRegion?: string,
   ): Promise<{
     hasInferenceProfile: boolean;
     isAccessible: boolean;
@@ -1332,6 +1337,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         availableProfileIds,
         preferRegional,
         abortSignal,
+        sourceRegion,
       );
     }
 
@@ -1360,6 +1366,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     availableProfileIds: Set<string>,
     preferRegional: boolean,
     abortSignal: AbortSignal,
+    sourceRegion?: string,
   ): Promise<{
     hasInferenceProfile: boolean;
     isAccessible: boolean;
@@ -1376,6 +1383,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         candidate.model.modelId,
         availableProfileIds,
         regionPrefix,
+        this.getRegionalProfilePriorityPrefixes(regionPrefix, sourceRegion),
         new Set([candidate.modelIdToUse]),
       );
       if (regionalProfileId) {
@@ -1441,6 +1449,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     modelId: string,
     availableProfileIds: Set<string>,
     regionPrefix: string,
+    profilePrefixPriority: string[],
     excludedProfileIds = new Set<string>(),
   ): string | undefined {
     const preferredProfileId = `${regionPrefix}.${modelId}`;
@@ -1451,12 +1460,20 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       return preferredProfileId;
     }
 
+    const priorityByPrefix = new Map(
+      profilePrefixPriority.map((prefix, index) => [prefix, index] as const),
+    );
+
     return [...availableProfileIds]
       .filter(
         (profileId) =>
           !excludedProfileIds.has(profileId) && this.isRegionalProfileForModel(profileId, modelId),
       )
-      .toSorted()[0];
+      .toSorted((a, b) => {
+        const aPriority = priorityByPrefix.get(a.split(".")[0]) ?? Number.MAX_SAFE_INTEGER;
+        const bPriority = priorityByPrefix.get(b.split(".")[0]) ?? Number.MAX_SAFE_INTEGER;
+        return aPriority - bPriority || a.localeCompare(b);
+      })[0];
   }
 
   /**
@@ -1592,6 +1609,52 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         result.sessionToken = sessionToken;
       }
       return result;
+    }
+
+    return undefined;
+  }
+
+  private getRegionalProfilePriorityPrefixes(
+    regionPrefix: string,
+    sourceRegion?: string,
+  ): string[] {
+    const prefixes = new Set<string>();
+    const geoPrefix = this.getSourceRegionGeoProfilePrefix(sourceRegion);
+
+    if (geoPrefix) {
+      prefixes.add(geoPrefix);
+    }
+    prefixes.add(regionPrefix);
+
+    return [...prefixes];
+  }
+
+  private getSourceRegionGeoProfilePrefix(sourceRegion?: string): string | undefined {
+    if (!sourceRegion) {
+      return undefined;
+    }
+
+    if (
+      (sourceRegion.startsWith("us-") && !sourceRegion.startsWith("us-gov-")) ||
+      sourceRegion.startsWith("ca-")
+    ) {
+      return "us";
+    }
+
+    if (sourceRegion.startsWith("eu-")) {
+      return "eu";
+    }
+
+    if (sourceRegion === "ap-northeast-1" || sourceRegion === "ap-northeast-3") {
+      return "jp";
+    }
+
+    if (
+      sourceRegion === "ap-southeast-2" ||
+      sourceRegion === "ap-southeast-4" ||
+      sourceRegion === "ap-southeast-6"
+    ) {
+      return "au";
     }
 
     return undefined;

--- a/src/test/bedrock-client.test.ts
+++ b/src/test/bedrock-client.test.ts
@@ -321,5 +321,39 @@ suite("BedrockAPIClient unit tests", () => {
       assert.ok(models.some((model) => model.modelId === "anthropic.claude-opus-4-7"));
       assert.ok(client.getFallbackInferenceProfileIds().has("jp.anthropic.claude-opus-4-7"));
     });
+
+    test("does not probe commercial US Claude 4.7 geo profiles in GovCloud", async () => {
+      const client = new BedrockAPIClient("us-gov-west-1");
+      const state = internals(client);
+      const probedProfileIds: string[] = [];
+
+      state.bedrockRuntimeClient = {
+        send: async (command) => {
+          const modelId = getCommandModelId(command);
+          if (modelId) {
+            probedProfileIds.push(modelId);
+          }
+          if (modelId === "us-gov-west.anthropic.claude-opus-4-7") {
+            return {};
+          }
+          throw runtimeValidationError();
+        },
+      };
+      state.bedrockClient = {
+        send: async () => ({
+          authorizationStatus: "NOT_AUTHORIZED",
+          regionAvailability: "UNAVAILABLE",
+        }),
+      };
+
+      const models = await state.detectAnthropicFallbackModels();
+
+      assert.equal(probedProfileIds.includes("us.anthropic.claude-opus-4-7"), false);
+      assert.ok(probedProfileIds.includes("us-gov-west.anthropic.claude-opus-4-7"));
+      assert.ok(models.some((model) => model.modelId === "anthropic.claude-opus-4-7"));
+      assert.ok(
+        client.getFallbackInferenceProfileIds().has("us-gov-west.anthropic.claude-opus-4-7"),
+      );
+    });
   });
 });

--- a/src/test/bedrock-client.test.ts
+++ b/src/test/bedrock-client.test.ts
@@ -1,10 +1,13 @@
+import { ValidationException } from "@aws-sdk/client-bedrock-runtime";
 import * as assert from "node:assert";
 
 import { BedrockAPIClient } from "../bedrock-client";
+import type { BedrockModelSummary } from "../types";
 
 interface BedrockAPIClientInternals {
   bedrockClient: MockSendClient;
   bedrockRuntimeClient: MockSendClient;
+  detectAnthropicFallbackModels: (abortSignal?: AbortSignal) => Promise<BedrockModelSummary[]>;
   inferenceProfileCache: Map<string, string>;
   unsupportedCountTokensModels: Set<string>;
 }
@@ -35,8 +38,19 @@ function awsError(
   return error;
 }
 
+function getCommandModelId(command: unknown): string | undefined {
+  return (command as { input?: { modelId?: string } }).input?.modelId;
+}
+
 function internals(client: BedrockAPIClient): BedrockAPIClientInternals {
   return client as unknown as BedrockAPIClientInternals;
+}
+
+function runtimeValidationError(): ValidationException {
+  return new ValidationException({
+    $metadata: { httpStatusCode: 400 },
+    message: "Model or inference profile is not accessible",
+  });
 }
 
 suite("BedrockAPIClient unit tests", () => {
@@ -157,6 +171,43 @@ suite("BedrockAPIClient unit tests", () => {
       assert.equal(resolvedModelId, "anthropic.claude-3-sonnet:0");
     });
 
+    test("resolves current geo dotted inference profiles", async () => {
+      const testCases = [
+        {
+          baseModelId: "anthropic.claude-opus-4-7",
+          profileId: "jp.anthropic.claude-opus-4-7",
+        },
+        {
+          baseModelId: "anthropic.claude-opus-4-7",
+          profileId: "au.anthropic.claude-opus-4-7",
+        },
+      ];
+
+      for (const { baseModelId, profileId } of testCases) {
+        const client = new BedrockAPIClient("us-east-1");
+        const state = internals(client);
+        let lookupCalls = 0;
+
+        state.bedrockClient = {
+          send: async () => {
+            lookupCalls += 1;
+            return {
+              models: [
+                {
+                  modelArn: `arn:aws:bedrock:us-east-1::foundation-model/${baseModelId}`,
+                },
+              ],
+            };
+          },
+        };
+
+        const resolvedModelId = await client.resolveModelId(profileId);
+
+        assert.equal(lookupCalls, 1);
+        assert.equal(resolvedModelId, baseModelId);
+      }
+    });
+
     test("does not cache aborted profile lookups", async () => {
       const client = new BedrockAPIClient("us-east-1");
       const state = internals(client);
@@ -196,6 +247,79 @@ suite("BedrockAPIClient unit tests", () => {
         state.inferenceProfileCache.get("global.openai.gpt-oss-120b-1:0"),
         "global.openai.gpt-oss-120b-1:0",
       );
+    });
+  });
+
+  suite("fallback Anthropic profile detection", () => {
+    test("detects Claude 4.7 models via known inference profiles", async () => {
+      const client = new BedrockAPIClient("us-east-1");
+      const state = internals(client);
+      const accessibleProfileIds = new Set([
+        "global.anthropic.claude-sonnet-4-7",
+        "us.anthropic.claude-opus-4-7",
+      ]);
+      const probedProfileIds: string[] = [];
+
+      state.bedrockRuntimeClient = {
+        send: async (command) => {
+          const modelId = getCommandModelId(command);
+          if (modelId) {
+            probedProfileIds.push(modelId);
+          }
+          if (modelId && accessibleProfileIds.has(modelId)) {
+            return {};
+          }
+          throw runtimeValidationError();
+        },
+      };
+      state.bedrockClient = {
+        send: async () => ({
+          authorizationStatus: "NOT_AUTHORIZED",
+          regionAvailability: "UNAVAILABLE",
+        }),
+      };
+
+      const models = await state.detectAnthropicFallbackModels();
+      const modelIds = new Set(models.map((model) => model.modelId));
+
+      assert.ok(modelIds.has("anthropic.claude-opus-4-7"));
+      assert.ok(modelIds.has("anthropic.claude-sonnet-4-7"));
+      assert.ok(probedProfileIds.includes("global.anthropic.claude-opus-4-7"));
+      assert.ok(probedProfileIds.includes("us.anthropic.claude-opus-4-7"));
+      assert.ok(probedProfileIds.includes("global.anthropic.claude-sonnet-4-7"));
+      assert.ok(client.getFallbackInferenceProfileIds().has("us.anthropic.claude-opus-4-7"));
+      assert.ok(client.getFallbackInferenceProfileIds().has("global.anthropic.claude-sonnet-4-7"));
+    });
+
+    test("uses model-specific Claude 4.7 geo profile prefixes", async () => {
+      const client = new BedrockAPIClient("ap-northeast-1");
+      const state = internals(client);
+      const probedProfileIds: string[] = [];
+
+      state.bedrockRuntimeClient = {
+        send: async (command) => {
+          const modelId = getCommandModelId(command);
+          if (modelId) {
+            probedProfileIds.push(modelId);
+          }
+          if (modelId === "jp.anthropic.claude-opus-4-7") {
+            return {};
+          }
+          throw runtimeValidationError();
+        },
+      };
+      state.bedrockClient = {
+        send: async () => ({
+          authorizationStatus: "NOT_AUTHORIZED",
+          regionAvailability: "UNAVAILABLE",
+        }),
+      };
+
+      const models = await state.detectAnthropicFallbackModels();
+
+      assert.ok(probedProfileIds.includes("jp.anthropic.claude-opus-4-7"));
+      assert.ok(models.some((model) => model.modelId === "anthropic.claude-opus-4-7"));
+      assert.ok(client.getFallbackInferenceProfileIds().has("jp.anthropic.claude-opus-4-7"));
     });
   });
 });

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -654,7 +654,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
         "us-west-2.anthropic.claude-3-5-sonnet-20241022-v2:0",
       ]);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -677,7 +677,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
         "us-west-2.anthropic.claude-3-5-sonnet-20241022-v2:0",
       ]);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -700,7 +700,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const models = [createTestModel("anthropic.claude-3-5-sonnet-20241022-v2:0")];
       const availableProfiles = new Set(["global.anthropic.claude-3-5-sonnet-20241022-v2:0"]);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -720,7 +720,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const models = [createTestModel("anthropic.claude-3-5-sonnet-20241022-v2:0")];
       const availableProfiles = new Set(["us-west-2.anthropic.claude-3-5-sonnet-20241022-v2:0"]);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -738,12 +738,30 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       assert.equal(candidates[0].hasInferenceProfile, true);
     });
 
+    test("uses detected regional profile when prefix differs from region prefix", () => {
+      const provider = new BedrockChatModelProvider(mockSecretStorage, mockGlobalState);
+      const models = [createTestModel("anthropic.claude-opus-4-7")];
+      const availableProfiles = new Set(["jp.anthropic.claude-opus-4-7"]);
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
+      const candidates = (provider as any).buildModelCandidates(
+        models,
+        availableProfiles,
+        "ap",
+        false,
+      );
+
+      assert.equal(candidates.length, 1);
+      assert.equal(candidates[0].modelIdToUse, "jp.anthropic.claude-opus-4-7");
+      assert.equal(candidates[0].hasInferenceProfile, true);
+    });
+
     test("no profiles available: uses base model", () => {
       const provider = new BedrockChatModelProvider(mockSecretStorage, mockGlobalState);
       const models = [createTestModel("anthropic.claude-3-5-sonnet-20241022-v2:0")];
       const availableProfiles = new Set<string>();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -768,7 +786,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       ];
       const availableProfiles = new Set<string>();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -789,7 +807,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       ];
       const availableProfiles = new Set<string>();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -806,7 +824,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const models = [model];
       const availableProfiles = new Set(["global.anthropic.claude-3-5-sonnet-20241022-v2:0"]);
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
         models,
         availableProfiles,
@@ -815,7 +833,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       );
 
       assert.equal(candidates.length, 1);
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidate = candidates[0];
       assert.ok(candidate);
 
@@ -842,7 +860,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       ]);
       const abortController = new AbortController();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const result = await (provider as any).findAlternativeProfile(
         candidate,
         "us-west-2",
@@ -856,6 +874,34 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       assert.equal(result.hasInferenceProfile, true);
 
       assert.equal(result.modelIdToUse, "us-west-2.anthropic.claude-3-5-sonnet-20241022-v2:0");
+    });
+
+    test("global failure falls back to alternate regional profile", async () => {
+      const provider = createMockClientProvider(false);
+      const model = createTestModel("anthropic.claude-opus-4-7");
+      const candidate = {
+        hasInferenceProfile: true,
+        model,
+        modelIdToUse: "global.anthropic.claude-opus-4-7",
+      };
+      const availableProfiles = new Set([
+        "global.anthropic.claude-opus-4-7",
+        "jp.anthropic.claude-opus-4-7",
+      ]);
+      const abortController = new AbortController();
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
+      const result = await (provider as any).findAlternativeProfile(
+        candidate,
+        "ap",
+        availableProfiles,
+        false,
+        abortController.signal,
+      );
+
+      assert.equal(result.isAccessible, true);
+      assert.equal(result.hasInferenceProfile, true);
+      assert.equal(result.modelIdToUse, "jp.anthropic.claude-opus-4-7");
     });
 
     test("preferRegional=false, regional fails: falls back to global profile", async () => {
@@ -872,7 +918,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       ]);
       const abortController = new AbortController();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const result = await (provider as any).findAlternativeProfile(
         candidate,
         "us-west-2",
@@ -902,7 +948,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       ]);
       const abortController = new AbortController();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const result = await (provider as any).findAlternativeProfile(
         candidate,
         "us-west-2",
@@ -934,7 +980,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       ]);
       const abortController = new AbortController();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const result = await (provider as any).findAlternativeProfile(
         candidate,
         "us-west-2",
@@ -963,7 +1009,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const availableProfiles = new Set(["global.anthropic.claude-3-5-sonnet-20241022-v2:0"]);
       const abortController = new AbortController();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const result = await (provider as any).findAlternativeProfile(
         candidate,
         "us-west-2",
@@ -990,7 +1036,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       const availableProfiles = new Set(["global.anthropic.claude-3-5-sonnet-20241022-v2:0"]);
       const abortController = new AbortController();
 
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const result = await (provider as any).findAlternativeProfile(
         candidate,
         "us-west-2",

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -741,7 +741,10 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     test("uses detected regional profile when prefix differs from region prefix", () => {
       const provider = new BedrockChatModelProvider(mockSecretStorage, mockGlobalState);
       const models = [createTestModel("anthropic.claude-opus-4-7")];
-      const availableProfiles = new Set(["jp.anthropic.claude-opus-4-7"]);
+      const availableProfiles = new Set([
+        "au.anthropic.claude-opus-4-7",
+        "jp.anthropic.claude-opus-4-7",
+      ]);
 
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- private-method test
       const candidates = (provider as any).buildModelCandidates(
@@ -749,6 +752,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
         availableProfiles,
         "ap",
         false,
+        "ap-northeast-1",
       );
 
       assert.equal(candidates.length, 1);
@@ -885,6 +889,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
         modelIdToUse: "global.anthropic.claude-opus-4-7",
       };
       const availableProfiles = new Set([
+        "au.anthropic.claude-opus-4-7",
         "global.anthropic.claude-opus-4-7",
         "jp.anthropic.claude-opus-4-7",
       ]);
@@ -897,6 +902,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
         availableProfiles,
         false,
         abortController.signal,
+        "ap-northeast-1",
       );
 
       assert.equal(result.isAccessible, true);


### PR DESCRIPTION
## What changed

- Added Claude Opus 4.7 and Claude Sonnet 4.7 to the Anthropic fallback profile probes used when `ListFoundationModels` is denied.
- Added support for current dotted geo inference profile prefixes such as `jp.` and `au.` when resolving profile IDs.
- Updated provider candidate selection to reuse detected regional profile IDs instead of reconstructing only `${regionPrefix}.${modelId}`.
- Added unit coverage for Claude 4.7 fallback detection and alternate regional profile selection.

## Why

The fallback model detection path was hard-coded around older inference profile naming. Newer Claude 4.7 profiles can use model-specific geo prefixes, so accessible Opus 4.7 or Sonnet 4.7 profiles could be missed even when the account can invoke them.

## Validation

- `bun run check-types`
- `bun run lint`
- `bun run test` (`83 passing`, `14 pending`)
- `bun run compile`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader inference-profile recognition across many AWS regions and caching of resolved base model IDs
  * Added support for Claude Opus 4.7 and Claude Sonnet 4.7 with regional profile generation
  * Regional-first model profile discovery with prioritized regional profile selection

* **Improvements**
  * More robust fallback ordering and reduced unnecessary retries when profile lookups are denied

* **Tests**
  * Expanded tests for regional resolution, profile probing, and fallback behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->