### PR TITLE
fix: Claude Haiku 4.5 and regional inference profiles stall when lacking bedrock:GetInferenceProfile permission

### DIFF
--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -439,12 +439,17 @@ export class BedrockAPIClient {
 
       return baseModelId;
     } catch (error) {
-      // If GetInferenceProfile fails, assume it's a regular model ID.
-      // Cache any permanent failure (AccessDenied, ResourceNotFound, ValidationException, etc.)
-      // so repeated calls (e.g. provideTokenCount called per-tool-per-turn by Copilot) don't
-      // keep hitting the API and trigger ThrottlingException.
-      // Only skip caching for AbortError (user cancellation) -- those should retry.
-      if (!this.isAbortError(error, abortSignal)) {
+      // Cache permanent failures (AccessDenied, ResourceNotFound, ValidationException) so
+      // repeated calls — provideTokenCount is called per-tool-per-turn by Copilot — don't
+      // flood the API and trigger ThrottlingException. Transient errors (throttling, 5xx,
+      // network) are not cached so they can be retried on the next call.
+      const isPermanent =
+        !this.isAbortError(error, abortSignal) &&
+        (this.isResourceNotFoundError(error) ||
+          this.getErrorCode(error) === "AccessDeniedException" ||
+          this.getErrorCode(error) === "ValidationException");
+
+      if (isPermanent) {
         this.inferenceProfileCache.set(modelId, modelId);
       }
       logger.trace(

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -439,9 +439,12 @@ export class BedrockAPIClient {
 
       return baseModelId;
     } catch (error) {
-      // If GetInferenceProfile fails, assume it's a regular model ID. Only
-      // cache definite misses; transient errors and cancellations should retry.
-      if (this.isResourceNotFoundError(error) && !this.isAbortError(error, abortSignal)) {
+      // If GetInferenceProfile fails, assume it's a regular model ID.
+      // Cache any permanent failure (AccessDenied, ResourceNotFound, ValidationException, etc.)
+      // so repeated calls (e.g. provideTokenCount called per-tool-per-turn by Copilot) don't
+      // keep hitting the API and trigger ThrottlingException.
+      // Only skip caching for AbortError (user cancellation) -- those should retry.
+      if (!this.isAbortError(error, abortSignal)) {
         this.inferenceProfileCache.set(modelId, modelId);
       }
       logger.trace(

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -164,7 +164,8 @@ export function getModelProfile(modelId: string): ModelProfile {
         (modelId.includes("opus-4") &&
           !modelId.includes("opus-4-7") &&
           !modelId.includes("opus-4-8")) ||
-        modelId.includes("sonnet-4");
+        modelId.includes("sonnet-4") ||
+        modelId.includes("haiku-4");
 
       // Claude models with extended thinking have issues with cachePoint after toolResult
       // When extended thinking is enabled, cachePoint should only be added to messages without toolResult


### PR DESCRIPTION
Fixes two bugs that together cause Claude Haiku 4.5 (and other `eu.`/`us.` regional inference profile models) to stall indefinitely at "Analyzing..." in Copilot Chat.

## Root causes

**1. Missing interleaved-thinking beta header for Haiku 4.5** (`src/profiles.ts`)

Haiku 4.5 is a Claude 4 family model and requires the `interleaved-thinking-2025-05-14` beta header when extended thinking is enabled. It was absent from `requiresInterleavedThinkingHeader` — only `opus-4` and `sonnet-4` were listed.

**2. `GetInferenceProfile` permanent failures not cached** (`src/bedrock-client.ts`)

VS Code Copilot calls `provideTokenCount` many times per request (once per tool, per message part). Each call invoked `resolveModelId`, which fired `GetInferenceProfile` for `eu.`/`us.`-prefixed model IDs. When the user lacks `bedrock:GetInferenceProfile` permission, `AccessDeniedException` was returned but not cached — only `ResourceNotFoundException` was. The flood of rapid-fire denied requests triggered `ThrottlingException`, stalling the entire chat turn.

Fix: cache permanent failures (`AccessDeniedException`, `ResourceNotFoundException`, `ValidationException`) so after the first denial the result is served from the in-memory cache. Transient errors (throttling, 5xx, network) are not cached so they can be retried.

## Testing

1. Configure the extension with a regional inference profile (e.g. `eu.anthropic.claude-haiku-4-5-20251001-v1:0`) in an AWS environment without the `bedrock:GetInferenceProfile` IAM permission
2. Send a message in Copilot Chat — the response should complete normally instead of stalling at "Analyzing..."
3. Check the extension logs: `GetInferenceProfile` should appear only once per model ID, not repeatedly across a single request

Working screenshot after changes:
<img width="628" height="2100" alt="image" src="https://github.com/user-attachments/assets/3b5419e8-d9de-43e8-a17c-83d588ab9134" />

## Related issues

Related to #455 and #527 — both describe Copilot stalling or being unexpectedly slow with the same pattern of repeated `resolveModelId`/`CountTokens` API calls flooding per turn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and caching to properly handle and cache permanent API failures including access and validation errors, improving reliability

* **New Features**
  * Extended interleaved thinking support to Claude Haiku 4 models, alongside existing Opus 4 and Sonnet 4 support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->