### PR TITLE
fix: remove region override from profile credential resolution

### DIFF
--- a/src/aws-profiles.ts
+++ b/src/aws-profiles.ts
@@ -1,4 +1,5 @@
 import { loadSharedConfigFiles, type SharedConfigInit } from "@smithy/shared-ini-file-loader";
+import type { IniSection } from "@smithy/types";
 
 import type { logger as Logger } from "./logger";
 
@@ -46,26 +47,41 @@ export async function getProfileSdkUaAppId(
 }
 
 /**
- * Determine whether a profile uses AWS IAM Identity Center / SSO configuration.
+ * Determine whether a profile uses AWS IAM Identity Center / SSO configuration,
+ * walking the `source_profile` chain so that assume-role profiles whose source
+ * resolves to an SSO/Identity Center profile are also detected.
+ *
  * For SSO profiles, passing an explicit region into fromIni() can break token
- * resolution. Assume-role and other profile types should continue to receive the
- * selected Bedrock region as STS client config.
+ * resolution -- and because `fromIni` propagates the same `clientConfig` while
+ * recursively resolving `source_profile`, chained profiles must be inspected as
+ * well. Assume-role and other non-SSO profile chains should continue to receive
+ * the selected Bedrock region as STS client config.
  */
 export async function isSsoProfile(profileName: string, init?: SharedConfigInit): Promise<boolean> {
   try {
     const { configFile, credentialsFile } = await loadSharedConfigFiles(init);
-    const profile = {
-      ...configFile?.[profileName],
-      ...credentialsFile?.[profileName],
-    };
+    const visited = new Set<string>();
+    let current: string | undefined = profileName;
+    while (typeof current === "string" && !visited.has(current)) {
+      visited.add(current);
+      const profile: IniSection = {
+        ...configFile?.[current],
+        ...credentialsFile?.[current],
+      };
 
-    return Boolean(
-      profile.sso_session ??
-      profile.sso_start_url ??
-      profile.sso_region ??
-      profile.sso_account_id ??
-      profile.sso_role_name,
-    );
+      if (
+        typeof profile.sso_session === "string" ||
+        typeof profile.sso_start_url === "string" ||
+        typeof profile.sso_region === "string" ||
+        typeof profile.sso_account_id === "string" ||
+        typeof profile.sso_role_name === "string"
+      ) {
+        return true;
+      }
+
+      current = profile.source_profile;
+    }
+    return false;
   } catch {
     return false;
   }

--- a/src/aws-profiles.ts
+++ b/src/aws-profiles.ts
@@ -46,6 +46,35 @@ export async function getProfileSdkUaAppId(
 }
 
 /**
+ * Determine whether a profile uses AWS IAM Identity Center / SSO configuration.
+ * For SSO profiles, passing an explicit region into fromIni() can break token
+ * resolution. Assume-role and other profile types should continue to receive the
+ * selected Bedrock region as STS client config.
+ */
+export async function isSsoProfile(
+  profileName: string,
+  init?: SharedConfigInit,
+): Promise<boolean> {
+  try {
+    const { configFile, credentialsFile } = await loadSharedConfigFiles(init);
+    const profile = {
+      ...configFile?.[profileName],
+      ...credentialsFile?.[profileName],
+    };
+
+    return Boolean(
+      profile.sso_session ??
+        profile.sso_start_url ??
+        profile.sso_region ??
+        profile.sso_account_id ??
+        profile.sso_role_name,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
  * List all available AWS profile names from credentials and config files
  * @param logger Optional logger instance to log errors
  * @param init Optional shared config loader options (useful for tests)

--- a/src/aws-profiles.ts
+++ b/src/aws-profiles.ts
@@ -51,10 +51,7 @@ export async function getProfileSdkUaAppId(
  * resolution. Assume-role and other profile types should continue to receive the
  * selected Bedrock region as STS client config.
  */
-export async function isSsoProfile(
-  profileName: string,
-  init?: SharedConfigInit,
-): Promise<boolean> {
+export async function isSsoProfile(profileName: string, init?: SharedConfigInit): Promise<boolean> {
   try {
     const { configFile, credentialsFile } = await loadSharedConfigFiles(init);
     const profile = {
@@ -64,10 +61,10 @@ export async function isSsoProfile(
 
     return Boolean(
       profile.sso_session ??
-        profile.sso_start_url ??
-        profile.sso_region ??
-        profile.sso_account_id ??
-        profile.sso_role_name,
+      profile.sso_start_url ??
+      profile.sso_region ??
+      profile.sso_account_id ??
+      profile.sso_role_name,
     );
   } catch {
     return false;

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -782,7 +782,9 @@ export class BedrockAPIClient {
     let provider: AwsCredentialIdentityProvider | undefined;
     const wrapped: AwsCredentialIdentityProvider = async () => {
       if (!provider) {
-        const useExplicitStsRegion = options?.stsRegion && !(await isSsoProfile(profile));
+        const stsRegion = options?.stsRegion;
+        const useExplicitStsRegion =
+          typeof stsRegion === "string" && !(await isSsoProfile(profile));
         const userAgentAppId = await getProfileSdkUaAppId(profile);
         if (userAgentAppId) {
           logger.debug(
@@ -792,7 +794,7 @@ export class BedrockAPIClient {
 
         provider = fromIni({
           clientConfig: {
-            ...(useExplicitStsRegion ? { region: options.stsRegion } : {}),
+            ...(useExplicitStsRegion ? { region: stsRegion } : {}),
             ...(userAgentAppId ? { userAgentAppId } : {}),
           },
           profile,

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -32,7 +32,7 @@ import {
   getRegionPrefix,
   supportsGlobalInferenceProfiles,
 } from "./aws-partition";
-import { getProfileSdkUaAppId } from "./aws-profiles";
+import { getProfileSdkUaAppId, isSsoProfile } from "./aws-profiles";
 import { logger } from "./logger";
 import type { AuthConfig, BedrockModelSummary } from "./types";
 
@@ -782,6 +782,7 @@ export class BedrockAPIClient {
     let provider: AwsCredentialIdentityProvider | undefined;
     const wrapped: AwsCredentialIdentityProvider = async () => {
       if (!provider) {
+        const useExplicitStsRegion = options?.stsRegion && !(await isSsoProfile(profile));
         const userAgentAppId = await getProfileSdkUaAppId(profile);
         if (userAgentAppId) {
           logger.debug(
@@ -791,7 +792,7 @@ export class BedrockAPIClient {
 
         provider = fromIni({
           clientConfig: {
-            ...(options?.stsRegion ? { region: options.stsRegion } : {}),
+            ...(useExplicitStsRegion ? { region: options.stsRegion } : {}),
             ...(userAgentAppId ? { userAgentAppId } : {}),
           },
           profile,

--- a/src/test/aws-profiles.test.ts
+++ b/src/test/aws-profiles.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
 
-import { getProfileSdkUaAppId, listAwsProfiles } from "../aws-profiles";
+import { getProfileSdkUaAppId, isSsoProfile, listAwsProfiles } from "../aws-profiles";
 
 suite("aws-profiles", () => {
   test("listAwsProfiles returns an array", async () => {
@@ -80,6 +80,144 @@ suite("aws-profiles", () => {
       });
 
       assert.strictEqual(appId, undefined);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  test("isSsoProfile returns true for a directly configured SSO profile", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "bedrock-profiles-"));
+    try {
+      const configFilepath = path.join(tempDir, "config");
+      const credentialsFilepath = path.join(tempDir, "credentials");
+
+      await writeFile(
+        configFilepath,
+        [
+          "[profile sso-direct]",
+          "sso_session = my-session",
+          "sso_account_id = 111111111111",
+          "sso_role_name = ReadOnly",
+          "region = us-east-1",
+          "",
+        ].join("\n"),
+      );
+      await writeFile(credentialsFilepath, "");
+
+      const result = await isSsoProfile("sso-direct", {
+        configFilepath,
+        filepath: credentialsFilepath,
+        ignoreCache: true,
+      });
+
+      assert.strictEqual(result, true);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  test("isSsoProfile returns true when source_profile chain resolves to an SSO profile", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "bedrock-profiles-"));
+    try {
+      const configFilepath = path.join(tempDir, "config");
+      const credentialsFilepath = path.join(tempDir, "credentials");
+
+      await writeFile(
+        configFilepath,
+        [
+          "[profile sso-base]",
+          "sso_session = my-session",
+          "sso_account_id = 111111111111",
+          "sso_role_name = ReadOnly",
+          "region = us-east-1",
+          "",
+          "[profile assume-role]",
+          "role_arn = arn:aws:iam::222222222222:role/AssumedRole",
+          "source_profile = sso-base",
+          "region = us-east-1",
+          "",
+        ].join("\n"),
+      );
+      await writeFile(credentialsFilepath, "");
+
+      const result = await isSsoProfile("assume-role", {
+        configFilepath,
+        filepath: credentialsFilepath,
+        ignoreCache: true,
+      });
+
+      assert.strictEqual(result, true);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  test("isSsoProfile returns false for a non-SSO assume-role chain", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "bedrock-profiles-"));
+    try {
+      const configFilepath = path.join(tempDir, "config");
+      const credentialsFilepath = path.join(tempDir, "credentials");
+
+      await writeFile(
+        configFilepath,
+        [
+          "[profile assume-role]",
+          "role_arn = arn:aws:iam::222222222222:role/AssumedRole",
+          "source_profile = static-base",
+          "region = us-east-1",
+          "",
+        ].join("\n"),
+      );
+      await writeFile(
+        credentialsFilepath,
+        [
+          "[static-base]",
+          "aws_access_key_id = AKIAEXAMPLE",
+          "aws_secret_access_key = secret",
+          "",
+        ].join("\n"),
+      );
+
+      const result = await isSsoProfile("assume-role", {
+        configFilepath,
+        filepath: credentialsFilepath,
+        ignoreCache: true,
+      });
+
+      assert.strictEqual(result, false);
+    } finally {
+      await rm(tempDir, { force: true, recursive: true });
+    }
+  });
+
+  test("isSsoProfile returns false when source_profile creates a cycle without SSO", async () => {
+    const tempDir = await mkdtemp(path.join(os.tmpdir(), "bedrock-profiles-"));
+    try {
+      const configFilepath = path.join(tempDir, "config");
+      const credentialsFilepath = path.join(tempDir, "credentials");
+
+      await writeFile(
+        configFilepath,
+        [
+          "[profile a]",
+          "role_arn = arn:aws:iam::222222222222:role/A",
+          "source_profile = b",
+          "",
+          "[profile b]",
+          "role_arn = arn:aws:iam::222222222222:role/B",
+          "source_profile = a",
+          "",
+        ].join("\n"),
+      );
+      await writeFile(credentialsFilepath, "");
+
+      const result = await isSsoProfile("a", {
+        configFilepath,
+        filepath: credentialsFilepath,
+        ignoreCache: true,
+      });
+
+      assert.strictEqual(result, false);
     } finally {
       await rm(tempDir, { force: true, recursive: true });
     }


### PR DESCRIPTION
This fixes Bedrock named-profile authentication failures that showed up as `UnauthorizedException: Session token not found or invalid` during model and inference-profile fetch, even when the same AWS profile could still be used successfully for SSM-based region discovery.

What changed:
- detect whether the configured profile is an SSO profile
- skip explicit `stsRegion` injection for SSO profiles when calling `fromIni()`
- preserve explicit STS region handling for assume-role and other non-SSO profiles
- keep `userAgentAppId` handling unchanged

Why:
Using an AWS SSO named profile could fail during Bedrock model and inference-profile fetch with `UnauthorizedException: Session token not found or invalid`, while the extension could still successfully use the same profile for SSM-based region discovery. The main behavioral difference was that the Bedrock client path injected a region into `fromIni()`, while the working SSM path did not.

Follow-up refinement:
A broader version of the fix risked regressing named profiles that rely on `role_arn` / `source_profile` and still need an explicit STS region fallback. The current change narrows the behavior to SSO / IAM Identity Center profiles only, so the original SSO auth bug is fixed without breaking assume-role profile resolution.

Validation:
- verified the patched TypeScript files have no relevant new editor errors
- confirmed the PR branch commit is SSH-signed and GitHub reports it as verified
- verified the same logic worked locally when patching the installed extension bundle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized AWS credential provider caching for improved performance and reliability.
  * Enhanced region configuration handling for AWS authentication, ensuring accurate credential resolution across different account configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->