### PR TITLE
improve performance and add new model support

### DIFF
--- a/package.json
+++ b/package.json
@@ -137,6 +137,15 @@
           "default": false,
           "description": "Prefer regional inference profiles over global ones. Enable this if your policies restrict access to global inference profiles. When enabled, the extension will use regional inference profiles (e.g., eu.anthropic.claude-opus-4-6-v1) instead of global ones (e.g., global.anthropic.claude-opus-4-6-v1).",
           "scope": "resource"
+        },
+        "bedrock.temperature.override": {
+          "type": [
+            "boolean",
+            "null"
+          ],
+          "default": null,
+          "markdownDescription": "Override temperature parameter handling globally. When set, this overrides the automatic `temperatureDeprecated` detection for all models. **null** (default) = use automatic detection based on model profiles; **true** = disable temperature parameter on all models (treat as deprecated); **false** = enable temperature parameter on all models (treat as not deprecated). Use this to work around models that incorrectly reject or require the temperature parameter.",
+          "scope": "resource"
         }
       }
     }

--- a/scripts/update-models-cache.sh
+++ b/scripts/update-models-cache.sh
@@ -14,11 +14,11 @@ TEMP_FILE=$(mktemp)
 trap 'rm -f "$TEMP_FILE"' EXIT
 
 echo "Fetching $URL ..."
-curl -fsSL "$URL" > "$TEMP_FILE"
+curl --connect-timeout 10 --max-time 60 -fsSL "$URL" > "$TEMP_FILE"
 
 # Extract only the amazon-bedrock section to keep the file small
 python3 <<PYTHON_EOF
-import os, sys, json
+import os, sys, json, tempfile
 
 try:
     with open('$TEMP_FILE', 'r') as f:
@@ -39,12 +39,20 @@ if not isinstance(models, dict):
 
 output = json.dumps({'amazon-bedrock': bedrock}, indent=2, sort_keys=True)
 
-# Write atomically: build the file next to the destination, then rename it
-# into place, so a crash or interruption never leaves a truncated cache.
-tmp_cache = '$CACHE_FILE' + '.tmp'
-with open(tmp_cache, 'w') as f:
-    f.write(output)
-os.replace(tmp_cache, '$CACHE_FILE')
+# Write atomically: build the file next to the destination (unique per
+# invocation so concurrent runs don't race on the same temp path), then
+# rename it into place so a crash or interruption never leaves a truncated
+# cache.
+cache_dir = os.path.dirname(os.path.abspath('$CACHE_FILE')) or '.'
+fd, tmp_cache = tempfile.mkstemp(dir=cache_dir, prefix='.models-dev-cache-', suffix='.tmp')
+try:
+    with os.fdopen(fd, 'w') as f:
+        f.write(output)
+    os.replace(tmp_cache, '$CACHE_FILE')
+except BaseException:
+    if os.path.exists(tmp_cache):
+        os.remove(tmp_cache)
+    raise
 
 MODEL_COUNT = len(models)
 print(f"Done. {MODEL_COUNT} models written to $CACHE_FILE")

--- a/scripts/update-models-cache.sh
+++ b/scripts/update-models-cache.sh
@@ -11,14 +11,14 @@ CACHE_FILE="src/models-dev-cache.json"
 URL="https://models.dev/api.json"
 TEMP_FILE=$(mktemp)
 
-trap "rm -f '$TEMP_FILE'" EXIT
+trap 'rm -f "$TEMP_FILE"' EXIT
 
 echo "Fetching $URL ..."
 curl -fsSL "$URL" > "$TEMP_FILE"
 
 # Extract only the amazon-bedrock section to keep the file small
 python3 <<PYTHON_EOF
-import sys, json
+import os, sys, json
 
 try:
     with open('$TEMP_FILE', 'r') as f:
@@ -28,15 +28,25 @@ except json.JSONDecodeError as e:
     sys.exit(1)
 
 bedrock = data.get('amazon-bedrock')
-if not bedrock:
-    print("ERROR: amazon-bedrock section not found in models.dev response", file=sys.stderr)
+if not isinstance(bedrock, dict):
+    print("ERROR: amazon-bedrock section not found or not an object in models.dev response", file=sys.stderr)
+    sys.exit(1)
+
+models = bedrock.get('models')
+if not isinstance(models, dict):
+    print("ERROR: amazon-bedrock.models is missing or not an object in models.dev response", file=sys.stderr)
     sys.exit(1)
 
 output = json.dumps({'amazon-bedrock': bedrock}, indent=2, sort_keys=True)
-with open('$CACHE_FILE', 'w') as f:
-    f.write(output)
 
-MODEL_COUNT = len(bedrock.get('models', {}))
+# Write atomically: build the file next to the destination, then rename it
+# into place, so a crash or interruption never leaves a truncated cache.
+tmp_cache = '$CACHE_FILE' + '.tmp'
+with open(tmp_cache, 'w') as f:
+    f.write(output)
+os.replace(tmp_cache, '$CACHE_FILE')
+
+MODEL_COUNT = len(models)
 print(f"Done. {MODEL_COUNT} models written to $CACHE_FILE")
 PYTHON_EOF
 

--- a/scripts/update-models-cache.sh
+++ b/scripts/update-models-cache.sh
@@ -9,27 +9,35 @@ set -euo pipefail
 
 CACHE_FILE="src/models-dev-cache.json"
 URL="https://models.dev/api.json"
+TEMP_FILE=$(mktemp)
+
+trap "rm -f '$TEMP_FILE'" EXIT
 
 echo "Fetching $URL ..."
-FULL=$(curl -fsSL "$URL")
+curl -fsSL "$URL" > "$TEMP_FILE"
 
 # Extract only the amazon-bedrock section to keep the file small
-python3 - <<'EOF'
+python3 <<PYTHON_EOF
 import sys, json
 
-with open('/dev/stdin') as f:
-    data = json.load(f)
+try:
+    with open('$TEMP_FILE', 'r') as f:
+        data = json.load(f)
+except json.JSONDecodeError as e:
+    print(f"ERROR: Invalid JSON from models.dev: {e}", file=sys.stderr)
+    sys.exit(1)
 
 bedrock = data.get('amazon-bedrock')
 if not bedrock:
     print("ERROR: amazon-bedrock section not found in models.dev response", file=sys.stderr)
     sys.exit(1)
 
-output = json.dumps({'amazon-bedrock': bedrock}, separators=(',', ':'), sort_keys=True)
-print(output)
-EOF
-<<< "$FULL" > "$CACHE_FILE"
+output = json.dumps({'amazon-bedrock': bedrock}, indent=2, sort_keys=True)
+with open('$CACHE_FILE', 'w') as f:
+    f.write(output)
 
-MODEL_COUNT=$(python3 -c "import json; d=json.load(open('$CACHE_FILE')); print(len(d['amazon-bedrock'].get('models', {})))")
-echo "Done. $MODEL_COUNT models written to $CACHE_FILE"
+MODEL_COUNT = len(bedrock.get('models', {}))
+print(f"Done. {MODEL_COUNT} models written to $CACHE_FILE")
+PYTHON_EOF
+
 echo "Review the diff and commit: git add $CACHE_FILE && git commit -m 'chore: update models.dev cache'"

--- a/src/bedrock-client.ts
+++ b/src/bedrock-client.ts
@@ -1,3 +1,9 @@
+/* eslint-disable unicorn/consistent-class-member-order -- AWS client methods are grouped by API workflow */
+/* eslint-disable unicorn/no-break-in-nested-loop -- cancellation checks intentionally short-circuit pagination */
+/* eslint-disable unicorn/no-error-property-assignment -- AbortError names are required by VS Code cancellation handling */
+/* eslint-disable unicorn/no-unreadable-for-of-expression -- AWS paginator iteration is the documented SDK pattern */
+/* eslint-disable unicorn/prefer-includes-over-repeated-comparisons -- model and region matching is clearer as explicit comparisons */
+
 import type { BedrockClientConfig } from "@aws-sdk/client-bedrock";
 import {
   AccessDeniedException,
@@ -34,8 +40,12 @@ import {
 } from "./aws-partition";
 import { getProfileSdkUaAppId, isSsoProfile } from "./aws-profiles";
 import { logger } from "./logger";
-import { loadModelsDevData } from "./models-dev";
-import type { AuthConfig, BedrockModelSummary, ModelsDevMap } from "./types";
+import { loadModelsDevData as loadModelsDevelopmentData } from "./models-dev";
+import type {
+  AuthConfig,
+  BedrockModelSummary,
+  ModelsDevMap as ModelsDevelopmentMap,
+} from "./types";
 
 export class BedrockAPIClient {
   private authConfig?: AuthConfig;
@@ -118,8 +128,8 @@ export class BedrockAPIClient {
 
       return response.inputTokens;
     } catch (error) {
-      const countTokensUnsupported = this.isUnsupportedCountTokensError(error, abortSignal);
-      if (countTokensUnsupported) {
+      const isCountTokensUnsupported = this.isUnsupportedCountTokensError(error, abortSignal);
+      if (isCountTokensUnsupported) {
         this.unsupportedCountTokensModels.add(modelId);
         if (baseModelId && baseModelId !== modelId) {
           this.unsupportedCountTokensModels.add(baseModelId);
@@ -143,7 +153,7 @@ export class BedrockAPIClient {
       // The caller should fall back to estimation. Logged at trace level because Copilot
       // Chat calls provideTokenCount many times per turn -- one line per call would
       // flood the output channel.
-      if (countTokensUnsupported) {
+      if (isCountTokensUnsupported) {
         logger.trace(
           `[Bedrock API Client] CountTokens not available for model ${modelId}: ${
             error instanceof Error ? error.message : String(error)
@@ -325,8 +335,8 @@ export class BedrockAPIClient {
    * (callers pass a signal they already have) but is unused because the
    * data comes from a local bundled file rather than a network request.
    */
-  async fetchModelsDevData(_abortSignal?: AbortSignal): Promise<ModelsDevMap> {
-    return loadModelsDevData();
+  async fetchModelsDevData(_abortSignal?: AbortSignal): Promise<ModelsDevelopmentMap> {
+    return loadModelsDevelopmentData();
   }
 
   /**
@@ -422,11 +432,11 @@ export class BedrockAPIClient {
     const arnProfilePattern =
       /^arn:aws(-[a-z0-9]+)?:bedrock:[a-z0-9-]+:\d{12}:(application-)?inference-profile\//;
     const appProfileIdPattern = /^ip-[a-z0-9]+/i;
-    const looksLikeProfile =
+    const isLooksLikeProfile =
       dotProfilePattern.test(modelId) ||
       arnProfilePattern.test(modelId) ||
       appProfileIdPattern.test(modelId);
-    if (!looksLikeProfile) {
+    if (!isLooksLikeProfile) {
       // Not an inference profile, return as-is
       return modelId;
     }
@@ -474,16 +484,28 @@ export class BedrockAPIClient {
   }
 
   setAuthConfig(authConfig: AuthConfig | undefined): void {
+    if (this.authConfigsEqual(this.authConfig, authConfig)) {
+      return;
+    }
+
     this.authConfig = authConfig;
     this.recreateClients();
   }
 
   setProfile(profileName: string | undefined): void {
+    if (this.profileName === profileName) {
+      return;
+    }
+
     this.profileName = profileName;
     this.recreateClients();
   }
 
   setRegion(region: string): void {
+    if (this.region === region) {
+      return;
+    }
+
     this.region = region;
     this.recreateClients();
   }
@@ -512,6 +534,33 @@ export class BedrockAPIClient {
    */
   async testInferenceProfileAccess(profileId: string, abortSignal?: AbortSignal): Promise<boolean> {
     return this.testAccessViaConverse(profileId, "Inference profile", abortSignal);
+  }
+
+  private authConfigsEqual(left: AuthConfig | undefined, right: AuthConfig | undefined): boolean {
+    if (left?.method !== right?.method) {
+      return false;
+    }
+
+    if (!left || !right) {
+      return left === right;
+    }
+
+    switch (left.method) {
+      case "access-keys": {
+        return (
+          right.method === "access-keys" &&
+          left.accessKeyId === right.accessKeyId &&
+          left.secretAccessKey === right.secretAccessKey &&
+          left.sessionToken === right.sessionToken
+        );
+      }
+      case "api-key": {
+        return right.method === "api-key" && left.apiKey === right.apiKey;
+      }
+      case "profile": {
+        return right.method === "profile" && left.profile === right.profile;
+      }
+    }
   }
 
   /**
@@ -609,11 +658,11 @@ export class BedrockAPIClient {
       candidates.map(async (candidate) => {
         // Try global profile first (if available in this partition)
         if (candidate.globalProfileId) {
-          const globalProfileAccessible = await this.testInferenceProfileAccess(
+          const isGlobalProfileAccessible = await this.testInferenceProfileAccess(
             candidate.globalProfileId,
             abortSignal,
           );
-          if (globalProfileAccessible) {
+          if (isGlobalProfileAccessible) {
             return { accessible: true, candidate, profileId: candidate.globalProfileId };
           }
           logger.debug(
@@ -623,11 +672,11 @@ export class BedrockAPIClient {
 
         // Try regional profiles
         for (const regionalProfileId of candidate.regionalProfileIds) {
-          const regionalProfileAccessible = await this.testInferenceProfileAccess(
+          const isRegionalProfileAccessible = await this.testInferenceProfileAccess(
             regionalProfileId,
             abortSignal,
           );
-          if (regionalProfileAccessible) {
+          if (isRegionalProfileAccessible) {
             if (candidate.globalProfileId) {
               logger.info(
                 `[Bedrock API Client] Global profile ${candidate.globalProfileId} denied, using regional profile ${regionalProfileId}`,
@@ -642,11 +691,11 @@ export class BedrockAPIClient {
         }
 
         // No accessible profile found, fall back to base model if reachable
-        const baseModelAccessible = await this.isModelAccessible(
+        const isBaseModelAccessible = await this.isModelAccessible(
           candidate.baseModelId,
           abortSignal,
         );
-        if (baseModelAccessible) {
+        if (isBaseModelAccessible) {
           logger.info(
             `[Bedrock API Client] No accessible inference profile for ${candidate.baseModelId}, using base model`,
           );
@@ -752,7 +801,7 @@ export class BedrockAPIClient {
         const creds: AwsCredentialIdentity = {
           accessKeyId: this.authConfig.accessKeyId,
           secretAccessKey: this.authConfig.secretAccessKey,
-          ...(this.authConfig.sessionToken ? { sessionToken: this.authConfig.sessionToken } : {}),
+          ...(this.authConfig.sessionToken && { sessionToken: this.authConfig.sessionToken }),
         };
         return { ...base, credentials: creds };
       }
@@ -804,7 +853,7 @@ export class BedrockAPIClient {
     const wrapped: AwsCredentialIdentityProvider = async () => {
       if (!provider) {
         const stsRegion = options?.stsRegion;
-        const useExplicitStsRegion =
+        const isUseExplicitStsRegion =
           typeof stsRegion === "string" && !(await isSsoProfile(profile));
         const userAgentAppId = await getProfileSdkUaAppId(profile);
         if (userAgentAppId) {
@@ -815,8 +864,8 @@ export class BedrockAPIClient {
 
         provider = fromIni({
           clientConfig: {
-            ...(useExplicitStsRegion ? { region: stsRegion } : {}),
-            ...(userAgentAppId ? { userAgentAppId } : {}),
+            ...(isUseExplicitStsRegion && { region: stsRegion }),
+            ...(userAgentAppId && { userAgentAppId }),
           },
           profile,
         });
@@ -980,3 +1029,9 @@ function getClaude47RegionalProfileIds(
 
   return [...prefixes].map((prefix) => `${prefix}.${baseModelId}`);
 }
+
+/* eslint-enable unicorn/consistent-class-member-order -- end intentional file-level exception */
+/* eslint-enable unicorn/no-break-in-nested-loop -- end intentional file-level exception */
+/* eslint-enable unicorn/no-error-property-assignment -- end intentional file-level exception */
+/* eslint-enable unicorn/no-unreadable-for-of-expression -- end intentional file-level exception */
+/* eslint-enable unicorn/prefer-includes-over-repeated-comparisons -- end intentional file-level exception */

--- a/src/converters/messages.ts
+++ b/src/converters/messages.ts
@@ -1,3 +1,7 @@
+/* eslint-disable unicorn/consistent-boolean-name -- names mirror VS Code and Bedrock message terminology */
+/* eslint-disable unicorn/prefer-includes-over-repeated-comparisons -- MIME and content checks are intentionally explicit */
+/* eslint-disable unicorn/prefer-simple-condition-first -- condition order preserves short-circuit safety */
+
 import {
   type Message as BedrockMessage,
   CachePointType,
@@ -49,9 +53,9 @@ export function convertMessages(
   });
 
   // Process each message by role
-  for (const msg of messages) {
-    if (msg.role === vscode.LanguageModelChatMessageRole.User) {
-      const { content, hasToolResults } = processUserMessageParts(msg, profile);
+  for (const message of messages) {
+    if (message.role === vscode.LanguageModelChatMessageRole.User) {
+      const { content, hasToolResults } = processUserMessageParts(message, profile);
       mergeOrAppendMessage(
         bedrockMessages,
         content,
@@ -59,8 +63,8 @@ export function convertMessages(
         hasToolResults,
         userMessageIndicesWithToolResults,
       );
-    } else if (msg.role === vscode.LanguageModelChatMessageRole.Assistant) {
-      const content = processAssistantMessageParts(msg);
+    } else if (message.role === vscode.LanguageModelChatMessageRole.Assistant) {
+      const content = processAssistantMessageParts(message);
       mergeOrAppendMessage(
         bedrockMessages,
         content,
@@ -70,7 +74,7 @@ export function convertMessages(
       );
     } else {
       // System messages
-      systemMessages.push(...processSystemMessageParts(msg));
+      systemMessages.push(...processSystemMessageParts(message));
     }
   }
 
@@ -140,12 +144,12 @@ function addPromptCachingPoints(
   } else if (!profile.supportsCachingWithToolResults) {
     // Model does NOT support caching with tool results: cache messages WITHOUT tool results
     const userMessagesWithoutToolResults: number[] = [];
-    for (const [i, message] of bedrockMessages.entries()) {
+    for (const [index, message] of bedrockMessages.entries()) {
       if (
         message?.role === ConversationRole.USER &&
-        !userMessageIndicesWithToolResults.includes(i)
+        !userMessageIndicesWithToolResults.includes(index)
       ) {
-        userMessagesWithoutToolResults.push(i);
+        userMessagesWithoutToolResults.push(index);
       }
     }
 
@@ -159,8 +163,8 @@ function addPromptCachingPoints(
   }
 
   // Add cache points to the selected messages
-  for (const idx of indicesToCache) {
-    const message = bedrockMessages[idx];
+  for (const index of indicesToCache) {
+    const message = bedrockMessages[index];
     if (message?.content !== undefined) {
       message.content.push({ cachePoint: { type: CachePointType.DEFAULT } });
     }
@@ -198,8 +202,14 @@ function extractToolResultText(content: unknown): string {
           mimeType: item.mimeType,
         });
       } else {
-        // For unknown types, try to stringify
-        textContent += inspect(item, { depth: 4 });
+        // For unknown types, use fast JSON.stringify instead of inspect
+        // inspect() with depth:4 is extremely slow on large objects (9-19KB)
+        try {
+          textContent += JSON.stringify(item);
+        } catch {
+          // Fallback if object is not serializable
+          textContent += String(item);
+        }
       }
     }
   } else if (typeof content === "string") {
@@ -210,7 +220,11 @@ function extractToolResultText(content: unknown): string {
       mimeType: content.mimeType,
     });
   } else {
-    textContent = inspect(content);
+    try {
+      textContent = JSON.stringify(content);
+    } catch {
+      textContent = String(content);
+    }
   }
   return textContent;
 }
@@ -232,21 +246,21 @@ function filterContentBlocks(
   let filteredCount = 0;
 
   for (const message of messages) {
-    if (message.content) {
-      const originalLength = message.content.length;
-      message.content = message.content.filter((block) => {
-        if (!predicate(block)) {
-          filteredCount++;
-          return false;
-        }
-        return true;
-      });
+    if (!message.content) {
+      continue;
+    }
 
-      if (message.content.length === 0 && originalLength > 0) {
-        logger.trace(
-          `[Message Converter] Message became empty after ${logContext}, will be removed`,
-        );
+    const originalLength = message.content.length;
+    message.content = message.content.filter((block) => {
+      if (!predicate(block)) {
+        filteredCount++;
+        return false;
       }
+      return true;
+    });
+
+    if (message.content.length === 0 && originalLength > 0) {
+      logger.trace(`[Message Converter] Message became empty after ${logContext}, will be removed`);
     }
   }
 
@@ -255,7 +269,7 @@ function filterContentBlocks(
   messages.splice(
     0,
     messages.length,
-    ...messages.filter((msg) => msg.content && msg.content.length > 0),
+    ...messages.filter((message) => message.content && message.content.length > 0),
   );
 
   if (filteredCount > 0) {
@@ -309,9 +323,9 @@ function injectExtendedThinking(
 
   // Find the LAST assistant message without reasoning content
   // We only inject into the last one because that's the only one we have a valid thinking block for
-  let lastAssistantIdx = -1;
-  for (let i = bedrockMessages.length - 1; i >= 0; i--) {
-    const message = bedrockMessages[i];
+  let lastAssistantIndex = -1;
+  for (let index = bedrockMessages.length - 1; index >= 0; index--) {
+    const message = bedrockMessages[index];
     if (
       message.role === ConversationRole.ASSISTANT &&
       message.content &&
@@ -322,18 +336,18 @@ function injectExtendedThinking(
       );
 
       if (!hasReasoning) {
-        lastAssistantIdx = i;
+        lastAssistantIndex = index;
         break;
       }
     }
   }
 
-  if (lastAssistantIdx === -1) {
+  if (lastAssistantIndex === -1) {
     logger.trace("[Message Converter] No assistant message found needing thinking block injection");
     return;
   }
 
-  const message = bedrockMessages[lastAssistantIdx];
+  const message = bedrockMessages[lastAssistantIndex];
   const reasoningBlock: ContentBlock.ReasoningContentMember = {
     reasoningContent: {
       reasoningText: {
@@ -345,7 +359,7 @@ function injectExtendedThinking(
 
   message.content!.unshift(reasoningBlock);
   logger.debug("[Message Converter] Injected thinking into last assistant message", {
-    messageIndex: lastAssistantIdx,
+    messageIndex: lastAssistantIndex,
     signatureLength: thinkingBlock.signature.length,
     textLength: thinkingBlock.text.length,
   });
@@ -433,10 +447,10 @@ function mergeOrAppendMessage(
 /**
  * Process all parts of an assistant message
  */
-function processAssistantMessageParts(msg: vscode.LanguageModelChatMessage): ContentBlock[] {
+function processAssistantMessageParts(message: vscode.LanguageModelChatMessage): ContentBlock[] {
   const content: ContentBlock[] = [];
 
-  for (const part of msg.content) {
+  for (const part of message.content) {
     if (part instanceof vscode.LanguageModelTextPart) {
       const block = processTextPart(part);
       if (block) content.push(block);
@@ -473,9 +487,8 @@ function processImagePart(part: ImageDataPart, role: ConversationRole): ContentB
             },
           },
         } satisfies ContentBlock.ImageMember;
-      } else {
-        logger.warn(`[Message Converter] Unsupported image format in ${role} message`, { format });
       }
+      logger.warn(`[Message Converter] Unsupported image format in ${role} message`, { format });
     }
   } catch (error) {
     logger.warn(`[Message Converter] Invalid MIME type in ${role} message`, {
@@ -489,10 +502,10 @@ function processImagePart(part: ImageDataPart, role: ConversationRole): ContentB
 /**
  * Process all parts of a system message
  */
-function processSystemMessageParts(msg: vscode.LanguageModelChatMessage): SystemContentBlock[] {
+function processSystemMessageParts(message: vscode.LanguageModelChatMessage): SystemContentBlock[] {
   const systemBlocks: SystemContentBlock[] = [];
 
-  for (const part of msg.content) {
+  for (const part of message.content) {
     if (part instanceof vscode.LanguageModelTextPart && part.value.trim()) {
       systemBlocks.push({ text: part.value });
     } else if (isMetadataPart(part)) {
@@ -558,15 +571,15 @@ function processToolResultPart(
     : ({ text: textContent } satisfies ToolResultContentBlock.TextMember);
 
   // Detect errors from explicit flag (when present) or content
-  const explicitIsError =
+  const isExplicitIsError =
     "isError" in part ? Boolean((part as Record<string, unknown>).isError) : false;
-  const isLikelyError = explicitIsError || detectToolResultError(textContent);
+  const isLikelyError = isExplicitIsError || detectToolResultError(textContent);
   const status = profile.supportsToolResultStatus && isLikelyError ? "error" : undefined;
 
   logger.debug("[Message Converter] Error status decision:", {
     contentLength: textContent.length,
-    detectedFromContent: !explicitIsError && isLikelyError,
-    explicitIsError,
+    detectedFromContent: !isExplicitIsError && isLikelyError,
+    explicitIsError: isExplicitIsError,
     hasIsErrorProperty: "isError" in part,
     modelSupportsStatus: profile.supportsToolResultStatus,
     resultingStatus: status,
@@ -583,7 +596,7 @@ function processToolResultPart(
     toolResult: {
       content: [contentBlock],
       toolUseId: part.callId,
-      ...(status ? { status } : {}),
+      ...(status && { status }),
     },
   } satisfies ContentBlock.ToolResultMember;
 }
@@ -592,13 +605,13 @@ function processToolResultPart(
  * Process all parts of a user message
  */
 function processUserMessageParts(
-  msg: vscode.LanguageModelChatMessage,
+  message: vscode.LanguageModelChatMessage,
   profile: ModelProfile,
 ): { content: ContentBlock[]; hasToolResults: boolean } {
   const content: ContentBlock[] = [];
   let hasToolResults = false;
 
-  for (const part of msg.content) {
+  for (const part of message.content) {
     if (part instanceof vscode.LanguageModelTextPart) {
       const block = processTextPart(part);
       if (block) content.push(block);
@@ -617,3 +630,7 @@ function processUserMessageParts(
 
   return { content, hasToolResults };
 }
+
+/* eslint-enable unicorn/consistent-boolean-name -- end intentional file-level exception */
+/* eslint-enable unicorn/prefer-includes-over-repeated-comparisons -- end intentional file-level exception */
+/* eslint-enable unicorn/prefer-simple-condition-first -- end intentional file-level exception */

--- a/src/models-dev-cache.json
+++ b/src/models-dev-cache.json
@@ -6,28 +6,58 @@
     "models": {
       "amazon.nova-2-lite-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.33, "output": 2.75 },
+        "cost": {
+          "input": 0.33,
+          "output": 2.75
+        },
+        "description": "Multimodal reasoning model for visual analysis, planning, and tool use",
         "family": "nova",
         "id": "amazon.nova-2-lite-v1:0",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
         "name": "Nova 2 Lite",
         "open_weights": false,
-        "reasoning": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          }
+        ],
         "release_date": "2024-12-01",
         "temperature": true,
         "tool_call": true
       },
       "amazon.nova-lite-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.015, "input": 0.06, "output": 0.24 },
+        "cost": {
+          "cache_read": 0.015,
+          "input": 0.06,
+          "output": 0.24
+        },
+        "description": "Efficient model for low-latency assistance, extraction, and routine automation",
         "family": "nova-lite",
         "id": "amazon.nova-lite-v1:0",
         "knowledge": "2024-10",
         "last_updated": "2024-12-03",
-        "limit": { "context": 300000, "output": 8192 },
-        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "limit": {
+          "context": 300000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
         "name": "Nova Lite",
         "open_weights": false,
         "reasoning": false,
@@ -37,13 +67,24 @@
       },
       "amazon.nova-micro-v1:0": {
         "attachment": false,
-        "cost": { "cache_read": 0.00875, "input": 0.035, "output": 0.14 },
+        "cost": {
+          "cache_read": 0.00875,
+          "input": 0.035,
+          "output": 0.14
+        },
+        "description": "Efficient model for low-latency assistance, extraction, and routine automation",
         "family": "nova-micro",
         "id": "amazon.nova-micro-v1:0",
         "knowledge": "2024-10",
         "last_updated": "2024-12-03",
-        "limit": { "context": 128000, "output": 8192 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Nova Micro",
         "open_weights": false,
         "reasoning": false,
@@ -53,13 +94,24 @@
       },
       "amazon.nova-pro-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.2, "input": 0.8, "output": 3.2 },
+        "cost": {
+          "cache_read": 0.2,
+          "input": 0.8,
+          "output": 3.2
+        },
+        "description": "Flagship model for demanding analysis, coding, and production agent workflows",
         "family": "nova-pro",
         "id": "amazon.nova-pro-v1:0",
         "knowledge": "2024-10",
         "last_updated": "2024-12-03",
-        "limit": { "context": 300000, "output": 8192 },
-        "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+        "limit": {
+          "context": 300000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image", "video"],
+          "output": ["text"]
+        },
         "name": "Nova Pro",
         "open_weights": false,
         "reasoning": false,
@@ -67,18 +119,70 @@
         "temperature": true,
         "tool_call": true
       },
+      "anthropic.claude-fable-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1,
+          "cache_write": 12.5,
+          "input": 10,
+          "output": 50
+        },
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "id": "anthropic.claude-fable-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-09",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Fable 5",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-09",
+        "temperature": false,
+        "tool_call": true
+      },
       "anthropic.claude-haiku-4-5-20251001-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.1, "cache_write": 1.25, "input": 1, "output": 5 },
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
         "family": "claude-haiku",
         "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
         "knowledge": "2025-02-28",
         "last_updated": "2025-10-15",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Haiku 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "structured_output": true,
         "temperature": true,
@@ -86,32 +190,73 @@
       },
       "anthropic.claude-opus-4-1-20250805-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 1.5, "cache_write": 18.75, "input": 15, "output": 75 },
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "anthropic.claude-opus-4-1-20250805-v1:0",
         "knowledge": "2025-03-31",
         "last_updated": "2025-08-05",
-        "limit": { "context": 200000, "output": 32000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-08-05",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
       "anthropic.claude-opus-4-5-20251101-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "anthropic.claude-opus-4-5-20251101-v1:0",
         "knowledge": "2025-03-31",
         "last_updated": "2025-08-01",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-11-24",
         "structured_output": true,
         "temperature": true,
@@ -119,16 +264,38 @@
       },
       "anthropic.claude-opus-4-6-v1": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
         "family": "claude-opus",
         "id": "anthropic.claude-opus-4-6-v1",
         "knowledge": "2025-05-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.6",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-05",
         "structured_output": true,
         "temperature": true,
@@ -136,47 +303,136 @@
       },
       "anthropic.claude-opus-4-7": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "anthropic.claude-opus-4-7",
         "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.7",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-04-16",
         "temperature": false,
         "tool_call": true
       },
       "anthropic.claude-opus-4-8": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "anthropic.claude-opus-4-8",
+        "knowledge": "2026-01",
         "last_updated": "2026-05-28",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.8",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "anthropic.claude-opus-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Strongest Claude Opus model for coding, agents, and professional work",
+        "family": "claude-opus",
+        "id": "anthropic.claude-opus-5",
+        "knowledge": "2026-05",
+        "last_updated": "2026-07-24",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Opus 5",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-24",
         "temperature": false,
         "tool_call": true
       },
       "anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
         "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
@@ -184,33 +440,111 @@
       },
       "anthropic.claude-sonnet-4-6": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
         "family": "claude-sonnet",
         "id": "anthropic.claude-sonnet-4-6",
         "knowledge": "2025-08-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.6",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "anthropic.claude-sonnet-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "input": 2,
+          "output": 10
+        },
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "id": "anthropic.claude-sonnet-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-30",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Sonnet 5",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-30",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "au.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.1, "cache_write": 1.25, "input": 1, "output": 5 },
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
         "family": "claude-haiku",
         "id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
         "knowledge": "2025-02-28",
         "last_updated": "2025-10-15",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Haiku 4.5 (AU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "structured_output": true,
         "temperature": true,
@@ -218,16 +552,38 @@
       },
       "au.anthropic.claude-opus-4-6-v1": {
         "attachment": true,
-        "cost": { "cache_read": 1.65, "cache_write": 20.625, "input": 16.5, "output": 82.5 },
+        "cost": {
+          "cache_read": 1.65,
+          "cache_write": 20.625,
+          "input": 16.5,
+          "output": 82.5
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "au.anthropic.claude-opus-4-6-v1",
         "knowledge": "2025-05",
         "last_updated": "2026-02-05",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "AU Anthropic Claude Opus 4.6",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-05",
         "structured_output": true,
         "temperature": true,
@@ -235,31 +591,102 @@
       },
       "au.anthropic.claude-opus-4-8": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "au.anthropic.claude-opus-4-8",
+        "knowledge": "2026-01",
         "last_updated": "2026-05-28",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.8 (AU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "au.anthropic.claude-opus-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Strongest Claude Opus model for coding, agents, and professional work",
+        "family": "claude-opus",
+        "id": "au.anthropic.claude-opus-5",
+        "knowledge": "2026-05",
+        "last_updated": "2026-07-24",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Opus 5 (AU)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-24",
         "temperature": false,
         "tool_call": true
       },
       "au.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.5 (AU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
@@ -267,49 +694,131 @@
       },
       "au.anthropic.claude-sonnet-4-6": {
         "attachment": true,
-        "cost": { "cache_read": 0.33, "cache_write": 4.125, "input": 3.3, "output": 16.5 },
+        "cost": {
+          "cache_read": 0.33,
+          "cache_write": 4.125,
+          "input": 3.3,
+          "output": 16.5
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "au.anthropic.claude-sonnet-4-6",
         "knowledge": "2025-08",
         "last_updated": "2026-02-17",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "AU Anthropic Claude Sonnet 4.6",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "au.anthropic.claude-sonnet-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "input": 2,
+          "output": 10
+        },
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "id": "au.anthropic.claude-sonnet-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-30",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Sonnet 5 (AU)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-30",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "deepseek.r1-v1:0": {
         "attachment": false,
-        "cost": { "input": 1.35, "output": 5.4 },
+        "cost": {
+          "input": 1.35,
+          "output": 5.4
+        },
+        "description": "DeepSeek reasoning model for multi-step analysis, math, coding, and tools",
         "family": "deepseek-thinking",
         "id": "deepseek.r1-v1:0",
         "knowledge": "2024-07",
         "last_updated": "2025-05-29",
-        "limit": { "context": 128000, "output": 32768 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "DeepSeek-R1",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-01-20",
         "temperature": true,
         "tool_call": true
       },
       "deepseek.v3-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.58, "output": 1.68 },
+        "cost": {
+          "input": 0.58,
+          "output": 1.68
+        },
+        "description": "DeepSeek chat model for instruction following, coding, and analysis",
         "family": "deepseek",
         "id": "deepseek.v3-v1:0",
         "knowledge": "2024-07",
         "last_updated": "2025-09-18",
-        "limit": { "context": 163840, "output": 81920 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 163840,
+          "output": 81920
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "DeepSeek-V3.1",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-09-18",
         "structured_output": true,
         "temperature": true,
@@ -317,33 +826,96 @@
       },
       "deepseek.v3.2": {
         "attachment": false,
-        "cost": { "input": 0.62, "output": 1.85 },
+        "cost": {
+          "input": 0.62,
+          "output": 1.85
+        },
+        "description": "DeepSeek chat model for instruction following, coding, and analysis",
         "family": "deepseek",
         "id": "deepseek.v3.2",
         "knowledge": "2024-07",
         "last_updated": "2026-02-06",
-        "limit": { "context": 163840, "output": 81920 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 163840,
+          "output": 81920
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "DeepSeek-V3.2",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-02-06",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "eu.anthropic.claude-fable-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1.1,
+          "cache_write": 13.75,
+          "input": 11,
+          "output": 55
+        },
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "id": "eu.anthropic.claude-fable-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-09",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Fable 5 (EU)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-09",
+        "temperature": false,
+        "tool_call": true
+      },
       "eu.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.1, "cache_write": 1.25, "input": 1, "output": 5 },
+        "cost": {
+          "cache_read": 0.11,
+          "cache_write": 1.375,
+          "input": 1.1,
+          "output": 5.5
+        },
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
         "family": "claude-haiku",
         "id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
         "knowledge": "2025-02-28",
         "last_updated": "2025-10-15",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Haiku 4.5 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "structured_output": true,
         "temperature": true,
@@ -351,16 +923,38 @@
       },
       "eu.anthropic.claude-opus-4-5-20251101-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "eu.anthropic.claude-opus-4-5-20251101-v1:0",
         "knowledge": "2025-03-31",
         "last_updated": "2025-08-01",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.5 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-11-24",
         "structured_output": true,
         "temperature": true,
@@ -368,16 +962,38 @@
       },
       "eu.anthropic.claude-opus-4-6-v1": {
         "attachment": true,
-        "cost": { "cache_read": 0.55, "cache_write": 6.875, "input": 5.5, "output": 27.5 },
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
+        },
+        "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
         "family": "claude-opus",
         "id": "eu.anthropic.claude-opus-4-6-v1",
         "knowledge": "2025-05-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.6 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-05",
         "structured_output": true,
         "temperature": true,
@@ -385,47 +1001,136 @@
       },
       "eu.anthropic.claude-opus-4-7": {
         "attachment": true,
-        "cost": { "cache_read": 0.55, "cache_write": 6.875, "input": 5.5, "output": 27.5 },
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "eu.anthropic.claude-opus-4-7",
         "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.7 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-04-16",
         "temperature": false,
         "tool_call": true
       },
       "eu.anthropic.claude-opus-4-8": {
         "attachment": true,
-        "cost": { "cache_read": 0.55, "cache_write": 6.875, "input": 5.5, "output": 27.5 },
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
+        },
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "eu.anthropic.claude-opus-4-8",
+        "knowledge": "2026-01",
         "last_updated": "2026-05-28",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.8 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "eu.anthropic.claude-opus-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "input": 5.5,
+          "output": 27.5
+        },
+        "description": "Strongest Claude Opus model for coding, agents, and professional work",
+        "family": "claude-opus",
+        "id": "eu.anthropic.claude-opus-5",
+        "knowledge": "2026-05",
+        "last_updated": "2026-07-24",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Opus 5 (EU)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-24",
         "temperature": false,
         "tool_call": true
       },
       "eu.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.33, "cache_write": 4.125, "input": 3.3, "output": 16.5 },
+        "cost": {
+          "cache_read": 0.33,
+          "cache_write": 4.125,
+          "input": 3.3,
+          "output": 16.5
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.5 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
@@ -433,33 +1138,145 @@
       },
       "eu.anthropic.claude-sonnet-4-6": {
         "attachment": true,
-        "cost": { "cache_read": 0.33, "cache_write": 4.125, "input": 3.3, "output": 16.5 },
+        "cost": {
+          "cache_read": 0.33,
+          "cache_write": 4.125,
+          "input": 3.3,
+          "output": 16.5
+        },
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
         "family": "claude-sonnet",
         "id": "eu.anthropic.claude-sonnet-4-6",
         "knowledge": "2025-08-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.6 (EU)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "eu.anthropic.claude-sonnet-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.22,
+          "cache_write": 2.75,
+          "input": 2.2,
+          "output": 11
+        },
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "id": "eu.anthropic.claude-sonnet-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-30",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Sonnet 5 (EU)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-30",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "global.anthropic.claude-fable-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1,
+          "cache_write": 12.5,
+          "input": 10,
+          "output": 50
+        },
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "id": "global.anthropic.claude-fable-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-09",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Fable 5 (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-09",
+        "temperature": false,
+        "tool_call": true
+      },
       "global.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.1, "cache_write": 1.25, "input": 1, "output": 5 },
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
         "family": "claude-haiku",
         "id": "global.anthropic.claude-haiku-4-5-20251001-v1:0",
         "knowledge": "2025-02-28",
         "last_updated": "2025-10-15",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Haiku 4.5 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "structured_output": true,
         "temperature": true,
@@ -467,16 +1284,38 @@
       },
       "global.anthropic.claude-opus-4-5-20251101-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
         "knowledge": "2025-03-31",
         "last_updated": "2025-08-01",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.5 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-11-24",
         "structured_output": true,
         "temperature": true,
@@ -484,16 +1323,38 @@
       },
       "global.anthropic.claude-opus-4-6-v1": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
         "family": "claude-opus",
         "id": "global.anthropic.claude-opus-4-6-v1",
         "knowledge": "2025-05-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.6 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-05",
         "structured_output": true,
         "temperature": true,
@@ -501,47 +1362,136 @@
       },
       "global.anthropic.claude-opus-4-7": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "global.anthropic.claude-opus-4-7",
         "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.7 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-04-16",
         "temperature": false,
         "tool_call": true
       },
       "global.anthropic.claude-opus-4-8": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "global.anthropic.claude-opus-4-8",
+        "knowledge": "2026-01",
         "last_updated": "2026-05-28",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.8 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "global.anthropic.claude-opus-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Strongest Claude Opus model for coding, agents, and professional work",
+        "family": "claude-opus",
+        "id": "global.anthropic.claude-opus-5",
+        "knowledge": "2026-05",
+        "last_updated": "2026-07-24",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Opus 5 (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-24",
         "temperature": false,
         "tool_call": true
       },
       "global.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.5 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
@@ -549,30 +1499,262 @@
       },
       "global.anthropic.claude-sonnet-4-6": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
         "family": "claude-sonnet",
         "id": "global.anthropic.claude-sonnet-4-6",
         "knowledge": "2025-08-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.6 (Global)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "global.anthropic.claude-sonnet-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "input": 2,
+          "output": 10
+        },
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "id": "global.anthropic.claude-sonnet-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-30",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Sonnet 5 (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-30",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "global.openai.gpt-5.6-luna": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.022,
+          "cache_write": 0.275,
+          "context_over_200k": {
+            "cache_read": 0.044,
+            "cache_write": 0.55,
+            "input": 0.44,
+            "output": 1.98
+          },
+          "input": 0.22,
+          "output": 1.32,
+          "tiers": [
+            {
+              "cache_read": 0.044,
+              "cache_write": 0.55,
+              "input": 0.44,
+              "output": 1.98,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-luna",
+        "id": "global.openai.gpt-5.6-luna",
+        "knowledge": "2026-02-16",
+        "last_updated": "2026-07-09",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.6 Luna (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-09",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "global.openai.gpt-5.6-sol": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "context_over_200k": {
+            "cache_read": 1.1,
+            "cache_write": 13.75,
+            "input": 11,
+            "output": 49.5
+          },
+          "input": 5.5,
+          "output": 33,
+          "tiers": [
+            {
+              "cache_read": 1.1,
+              "cache_write": 13.75,
+              "input": 11,
+              "output": 49.5,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt-sol",
+        "id": "global.openai.gpt-5.6-sol",
+        "knowledge": "2026-02-16",
+        "last_updated": "2026-07-09",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.6 Sol (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-09",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "global.openai.gpt-5.6-terra": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.22,
+          "cache_write": 2.75,
+          "context_over_200k": {
+            "cache_read": 0.44,
+            "cache_write": 5.5,
+            "input": 4.4,
+            "output": 19.8
+          },
+          "input": 2.2,
+          "output": 13.2,
+          "tiers": [
+            {
+              "cache_read": 0.44,
+              "cache_write": 5.5,
+              "input": 4.4,
+              "output": 19.8,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-terra",
+        "id": "global.openai.gpt-5.6-terra",
+        "knowledge": "2026-02-16",
+        "last_updated": "2026-07-09",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.6 Terra (Global)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-09",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "google.gemma-3-12b-it": {
         "attachment": false,
-        "cost": { "input": 0.049999999999999996, "output": 0.09999999999999999 },
+        "cost": {
+          "input": 0.049999999999999996,
+          "output": 0.09999999999999999
+        },
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
         "family": "gemma",
         "id": "google.gemma-3-12b-it",
         "knowledge": "2024-12",
         "last_updated": "2024-12-01",
-        "limit": { "context": 131072, "output": 8192 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 131072,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Google Gemma 3 12B",
         "open_weights": false,
         "reasoning": false,
@@ -583,13 +1765,23 @@
       },
       "google.gemma-3-27b-it": {
         "attachment": true,
-        "cost": { "input": 0.12, "output": 0.2 },
+        "cost": {
+          "input": 0.12,
+          "output": 0.2
+        },
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
         "family": "gemma",
         "id": "google.gemma-3-27b-it",
         "knowledge": "2025-07",
         "last_updated": "2025-07-27",
-        "limit": { "context": 202752, "output": 8192 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 202752,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Google Gemma 3 27B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -600,12 +1792,22 @@
       },
       "google.gemma-3-4b-it": {
         "attachment": false,
-        "cost": { "input": 0.04, "output": 0.08 },
+        "cost": {
+          "input": 0.04,
+          "output": 0.08
+        },
+        "description": "Open Gemma instruction model for efficient chat and self-hosted deployments",
         "family": "gemma",
         "id": "google.gemma-3-4b-it",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Gemma 3 4B IT",
         "open_weights": false,
         "reasoning": false,
@@ -613,49 +1815,173 @@
         "temperature": true,
         "tool_call": true
       },
+      "jp.anthropic.claude-haiku-4-5-20251001-v1:0": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
+        "family": "claude-haiku",
+        "id": "jp.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "knowledge": "2025-02-28",
+        "last_updated": "2025-10-15",
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Haiku 4.5 (JP)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
+        "release_date": "2025-10-15",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
       "jp.anthropic.claude-opus-4-7": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Stronger Opus tier for advanced software work and high-stakes reasoning",
         "family": "claude-opus",
         "id": "jp.anthropic.claude-opus-4-7",
         "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.7 (JP)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-04-16",
         "temperature": false,
         "tool_call": true
       },
       "jp.anthropic.claude-opus-4-8": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "jp.anthropic.claude-opus-4-8",
+        "knowledge": "2026-01",
         "last_updated": "2026-05-28",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.8 (JP)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "jp.anthropic.claude-opus-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Strongest Claude Opus model for coding, agents, and professional work",
+        "family": "claude-opus",
+        "id": "jp.anthropic.claude-opus-5",
+        "knowledge": "2026-05",
+        "last_updated": "2026-07-24",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Opus 5 (JP)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-24",
         "temperature": false,
         "tool_call": true
       },
       "jp.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.5 (JP)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
@@ -663,30 +1989,100 @@
       },
       "jp.anthropic.claude-sonnet-4-6": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
         "family": "claude-sonnet",
         "id": "jp.anthropic.claude-sonnet-4-6",
         "knowledge": "2025-08-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.6 (JP)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "jp.anthropic.claude-sonnet-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "input": 2,
+          "output": 10
+        },
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "id": "jp.anthropic.claude-sonnet-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-30",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Sonnet 5 (JP)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-30",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "meta.llama3-1-70b-instruct-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.72, "output": 0.72 },
+        "cost": {
+          "input": 0.72,
+          "output": 0.72
+        },
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
         "family": "llama",
         "id": "meta.llama3-1-70b-instruct-v1:0",
         "knowledge": "2023-12",
         "last_updated": "2024-07-23",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Llama 3.1 70B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -696,13 +2092,23 @@
       },
       "meta.llama3-1-8b-instruct-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.22, "output": 0.22 },
+        "cost": {
+          "input": 0.22,
+          "output": 0.22
+        },
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
         "family": "llama",
         "id": "meta.llama3-1-8b-instruct-v1:0",
         "knowledge": "2023-12",
         "last_updated": "2024-07-23",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Llama 3.1 8B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -712,13 +2118,23 @@
       },
       "meta.llama3-3-70b-instruct-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.72, "output": 0.72 },
+        "cost": {
+          "input": 0.72,
+          "output": 0.72
+        },
+        "description": "Open Llama instruction model for multilingual chat, reasoning, and coding",
         "family": "llama",
         "id": "meta.llama3-3-70b-instruct-v1:0",
         "knowledge": "2023-12",
         "last_updated": "2024-12-06",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Llama 3.3 70B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -728,13 +2144,23 @@
       },
       "meta.llama4-maverick-17b-instruct-v1:0": {
         "attachment": true,
-        "cost": { "input": 0.24, "output": 0.97 },
+        "cost": {
+          "input": 0.24,
+          "output": 0.97
+        },
+        "description": "Open multimodal Llama model for strong reasoning and fast responses",
         "family": "llama",
         "id": "meta.llama4-maverick-17b-instruct-v1:0",
         "knowledge": "2024-08",
         "last_updated": "2025-04-05",
-        "limit": { "context": 1000000, "output": 16384 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Llama 4 Maverick 17B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -744,13 +2170,23 @@
       },
       "meta.llama4-scout-17b-instruct-v1:0": {
         "attachment": true,
-        "cost": { "input": 0.17, "output": 0.66 },
+        "cost": {
+          "input": 0.17,
+          "output": 0.66
+        },
+        "description": "Open multimodal Llama model for long-context analysis and efficient agents",
         "family": "llama",
         "id": "meta.llama4-scout-17b-instruct-v1:0",
         "knowledge": "2024-08",
         "last_updated": "2025-04-05",
-        "limit": { "context": 3500000, "output": 16384 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 3500000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Llama 4 Scout 17B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -760,15 +2196,26 @@
       },
       "minimax.minimax-m2": {
         "attachment": false,
-        "cost": { "input": 0.3, "output": 1.2 },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "description": "MiniMax model for chat, coding, office work, and agentic tasks",
         "family": "minimax",
         "id": "minimax.minimax-m2",
         "last_updated": "2025-10-27",
-        "limit": { "context": 204608, "output": 128000 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 204608,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "MiniMax M2",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-10-27",
         "structured_output": false,
         "temperature": true,
@@ -776,15 +2223,26 @@
       },
       "minimax.minimax-m2.1": {
         "attachment": false,
-        "cost": { "input": 0.3, "output": 1.2 },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "description": "MiniMax model for chat, coding, office work, and agentic tasks",
         "family": "minimax",
         "id": "minimax.minimax-m2.1",
         "last_updated": "2025-12-23",
-        "limit": { "context": 204800, "output": 131072 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "MiniMax M2.1",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-12-23",
         "structured_output": false,
         "temperature": true,
@@ -792,15 +2250,26 @@
       },
       "minimax.minimax-m2.5": {
         "attachment": false,
-        "cost": { "input": 0.3, "output": 1.2 },
+        "cost": {
+          "input": 0.3,
+          "output": 1.2
+        },
+        "description": "MiniMax model for chat, coding, office work, and agentic tasks",
         "family": "minimax",
         "id": "minimax.minimax-m2.5",
         "last_updated": "2026-03-18",
-        "limit": { "context": 196608, "output": 98304 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 196608,
+          "output": 98304
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "MiniMax M2.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-03-18",
         "structured_output": false,
         "temperature": true,
@@ -808,12 +2277,22 @@
       },
       "mistral.devstral-2-123b": {
         "attachment": false,
-        "cost": { "input": 0.4, "output": 2 },
+        "cost": {
+          "input": 0.4,
+          "output": 2
+        },
+        "description": "Mistral coding agent model for repository tasks and software engineering workflows",
         "family": "devstral",
         "id": "mistral.devstral-2-123b",
         "last_updated": "2026-02-17",
-        "limit": { "context": 256000, "output": 8192 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 256000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Devstral 2 123B",
         "open_weights": true,
         "reasoning": false,
@@ -824,15 +2303,26 @@
       },
       "mistral.magistral-small-2509": {
         "attachment": false,
-        "cost": { "input": 0.5, "output": 1.5 },
+        "cost": {
+          "input": 0.5,
+          "output": 1.5
+        },
+        "description": "Mistral reasoning model for transparent analysis, math, and complex decisions",
         "family": "magistral",
         "id": "mistral.magistral-small-2509",
         "last_updated": "2025-12-02",
-        "limit": { "context": 128000, "output": 40000 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 40000
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Magistral Small 1.2",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-12-02",
         "structured_output": true,
         "temperature": true,
@@ -840,12 +2330,22 @@
       },
       "mistral.ministral-3-14b-instruct": {
         "attachment": false,
-        "cost": { "input": 0.2, "output": 0.2 },
+        "cost": {
+          "input": 0.2,
+          "output": 0.2
+        },
+        "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
         "family": "ministral",
         "id": "mistral.ministral-3-14b-instruct",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Ministral 14B 3.0",
         "open_weights": false,
         "reasoning": false,
@@ -856,12 +2356,22 @@
       },
       "mistral.ministral-3-3b-instruct": {
         "attachment": false,
-        "cost": { "input": 0.1, "output": 0.1 },
+        "cost": {
+          "input": 0.1,
+          "output": 0.1
+        },
+        "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
         "family": "ministral",
         "id": "mistral.ministral-3-3b-instruct",
         "last_updated": "2025-12-02",
-        "limit": { "context": 256000, "output": 8192 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 256000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Ministral 3 3B",
         "open_weights": true,
         "reasoning": false,
@@ -872,12 +2382,22 @@
       },
       "mistral.ministral-3-8b-instruct": {
         "attachment": false,
-        "cost": { "input": 0.15, "output": 0.15 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.15
+        },
+        "description": "Compact Mistral model for edge, latency-sensitive, and cost-efficient workloads",
         "family": "ministral",
         "id": "mistral.ministral-3-8b-instruct",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Ministral 3 8B",
         "open_weights": false,
         "reasoning": false,
@@ -888,12 +2408,22 @@
       },
       "mistral.mistral-large-3-675b-instruct": {
         "attachment": false,
-        "cost": { "input": 0.5, "output": 1.5 },
+        "cost": {
+          "input": 0.5,
+          "output": 1.5
+        },
+        "description": "Flagship Mistral model for advanced reasoning, coding, and multilingual work",
         "family": "mistral",
         "id": "mistral.mistral-large-3-675b-instruct",
         "last_updated": "2025-12-02",
-        "limit": { "context": 256000, "output": 8192 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 256000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Mistral Large 3",
         "open_weights": true,
         "reasoning": false,
@@ -904,12 +2434,22 @@
       },
       "mistral.pixtral-large-2502-v1:0": {
         "attachment": false,
-        "cost": { "input": 2, "output": 6 },
+        "cost": {
+          "input": 2,
+          "output": 6
+        },
+        "description": "Mistral vision-language model for image understanding and multimodal chat",
         "family": "mistral",
         "id": "mistral.pixtral-large-2502-v1:0",
         "last_updated": "2025-04-08",
-        "limit": { "context": 128000, "output": 8192 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Pixtral Large (25.02)",
         "open_weights": false,
         "reasoning": false,
@@ -919,12 +2459,22 @@
       },
       "mistral.voxtral-mini-3b-2507": {
         "attachment": false,
-        "cost": { "input": 0.04, "output": 0.04 },
+        "cost": {
+          "input": 0.04,
+          "output": 0.04
+        },
+        "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
         "family": "mistral",
         "id": "mistral.voxtral-mini-3b-2507",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["audio", "text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["audio", "text"],
+          "output": ["text"]
+        },
         "name": "Voxtral Mini 3B 2507",
         "open_weights": false,
         "reasoning": false,
@@ -935,12 +2485,22 @@
       },
       "mistral.voxtral-small-24b-2507": {
         "attachment": true,
-        "cost": { "input": 0.15, "output": 0.35 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.35
+        },
+        "description": "Efficient Mistral model for fast chat, extraction, and production assistants",
         "family": "mistral",
         "id": "mistral.voxtral-small-24b-2507",
         "last_updated": "2025-07-01",
-        "limit": { "context": 32000, "output": 8192 },
-        "modalities": { "input": ["text", "audio"], "output": ["text"] },
+        "limit": {
+          "context": 32000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text", "audio"],
+          "output": ["text"]
+        },
         "name": "Voxtral Small 24B 2507",
         "open_weights": true,
         "reasoning": false,
@@ -951,16 +2511,27 @@
       },
       "moonshot.kimi-k2-thinking": {
         "attachment": false,
-        "cost": { "input": 0.6, "output": 2.5 },
+        "cost": {
+          "input": 0.6,
+          "output": 2.5
+        },
+        "description": "Kimi reasoning model for long-horizon research, planning, and tool use",
         "family": "kimi-thinking",
         "id": "moonshot.kimi-k2-thinking",
         "interleaved": true,
         "last_updated": "2025-12-02",
-        "limit": { "context": 262143, "output": 16000 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 262143,
+          "output": 16000
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Kimi K2 Thinking",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-12-02",
         "structured_output": true,
         "temperature": true,
@@ -968,16 +2539,27 @@
       },
       "moonshotai.kimi-k2.5": {
         "attachment": false,
-        "cost": { "input": 0.6, "output": 3 },
+        "cost": {
+          "input": 0.6,
+          "output": 3
+        },
+        "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
         "family": "kimi",
         "id": "moonshotai.kimi-k2.5",
         "interleaved": true,
         "last_updated": "2026-02-06",
-        "limit": { "context": 262143, "output": 16000 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 262143,
+          "output": 16000
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Kimi K2.5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-02-06",
         "structured_output": true,
         "temperature": true,
@@ -985,12 +2567,22 @@
       },
       "nvidia.nemotron-nano-12b-v2": {
         "attachment": false,
-        "cost": { "input": 0.2, "output": 0.6 },
+        "cost": {
+          "input": 0.2,
+          "output": 0.6
+        },
+        "description": "Nemotron multimodal model for visual reasoning and agentic AI workflows",
         "family": "nemotron",
         "id": "nvidia.nemotron-nano-12b-v2",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "NVIDIA Nemotron Nano 12B v2 VL BF16",
         "open_weights": false,
         "reasoning": false,
@@ -1001,15 +2593,26 @@
       },
       "nvidia.nemotron-nano-3-30b": {
         "attachment": false,
-        "cost": { "input": 0.06, "output": 0.24 },
+        "cost": {
+          "input": 0.06,
+          "output": 0.24
+        },
+        "description": "Small Nemotron 3 MoE for efficient coding, math, and long-context agents",
         "family": "nemotron",
         "id": "nvidia.nemotron-nano-3-30b",
         "last_updated": "2025-12-23",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "NVIDIA Nemotron Nano 3 30B",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-12-23",
         "structured_output": true,
         "temperature": true,
@@ -1017,12 +2620,22 @@
       },
       "nvidia.nemotron-nano-9b-v2": {
         "attachment": false,
-        "cost": { "input": 0.06, "output": 0.23 },
+        "cost": {
+          "input": 0.06,
+          "output": 0.23
+        },
+        "description": "Compact Nemotron model for efficient reasoning and deployable AI agents",
         "family": "nemotron",
         "id": "nvidia.nemotron-nano-9b-v2",
         "last_updated": "2024-12-01",
-        "limit": { "context": 128000, "output": 4096 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 4096
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "NVIDIA Nemotron Nano 9B v2",
         "open_weights": false,
         "reasoning": false,
@@ -1033,31 +2646,387 @@
       },
       "nvidia.nemotron-super-3-120b": {
         "attachment": false,
-        "cost": { "input": 0.15, "output": 0.65 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.65
+        },
+        "description": "Nemotron middle tier for collaborative agents and high-volume reasoning workloads",
         "family": "nemotron",
         "id": "nvidia.nemotron-super-3-120b",
         "last_updated": "2026-03-11",
-        "limit": { "context": 262144, "output": 131072 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "NVIDIA Nemotron 3 Super 120B A12B",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-03-11",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai.gpt-5.4": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.275,
+          "input": 2.75,
+          "output": 16.5
+        },
+        "description": "Agent-ready GPT for coding and computer-use workflows at a lower cost",
+        "family": "gpt",
+        "id": "openai.gpt-5.4",
+        "knowledge": "2025-08-31",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.4",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh"]
+          }
+        ],
+        "release_date": "2026-03-05",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai.gpt-5.5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "input": 5.5,
+          "output": 33
+        },
+        "description": "Default frontier GPT for coding, computer use, research, and knowledge work",
+        "family": "gpt",
+        "id": "openai.gpt-5.5",
+        "knowledge": "2025-12-01",
+        "last_updated": "2026-06-01",
+        "limit": {
+          "context": 272000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.5",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh"]
+          }
+        ],
+        "release_date": "2026-04-23",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai.gpt-5.6-luna": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.022,
+          "cache_write": 0.275,
+          "context_over_200k": {
+            "cache_read": 0.044,
+            "cache_write": 0.55,
+            "input": 0.44,
+            "output": 1.98
+          },
+          "input": 0.22,
+          "output": 1.32,
+          "tiers": [
+            {
+              "cache_read": 0.044,
+              "cache_write": 0.55,
+              "input": 0.44,
+              "output": 1.98,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "description": "Cost-efficient GPT-5.6 model for fast, high-volume workloads",
+        "family": "gpt-luna",
+        "id": "openai.gpt-5.6-luna",
+        "knowledge": "2026-02-16",
+        "last_updated": "2026-07-09",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.6 Luna",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-09",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai.gpt-5.6-sol": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "cache_write": 6.875,
+          "context_over_200k": {
+            "cache_read": 1.1,
+            "cache_write": 13.75,
+            "input": 11,
+            "output": 49.5
+          },
+          "input": 5.5,
+          "output": 33,
+          "tiers": [
+            {
+              "cache_read": 1.1,
+              "cache_write": 13.75,
+              "input": 11,
+              "output": 49.5,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "description": "Frontier GPT-5.6 model for complex professional work, coding, and agentic workflows",
+        "family": "gpt-sol",
+        "id": "openai.gpt-5.6-sol",
+        "knowledge": "2026-02-16",
+        "last_updated": "2026-07-09",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.6 Sol",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-09",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai.gpt-5.6-terra": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.22,
+          "cache_write": 2.75,
+          "context_over_200k": {
+            "cache_read": 0.44,
+            "cache_write": 5.5,
+            "input": 4.4,
+            "output": 19.8
+          },
+          "input": 2.2,
+          "output": 13.2,
+          "tiers": [
+            {
+              "cache_read": 0.44,
+              "cache_write": 5.5,
+              "input": 4.4,
+              "output": 19.8,
+              "tier": {
+                "size": 272000,
+                "type": "context"
+              }
+            }
+          ]
+        },
+        "description": "Balanced GPT-5.6 model for capable, cost-efficient everyday work",
+        "family": "gpt-terra",
+        "id": "openai.gpt-5.6-terra",
+        "knowledge": "2026-02-16",
+        "last_updated": "2026-07-09",
+        "limit": {
+          "context": 1050000,
+          "input": 922000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "GPT-5.6 Terra",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-09",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
+      "openai.gpt-oss-120b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
+        "family": "gpt-oss",
+        "id": "openai.gpt-oss-120b",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "name": "gpt-oss-120b",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          }
+        ],
+        "release_date": "2025-08-05",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "openai.gpt-oss-120b-1:0": {
         "attachment": false,
-        "cost": { "input": 0.15, "output": 0.6 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
         "family": "gpt-oss",
         "id": "openai.gpt-oss-120b-1:0",
         "last_updated": "2025-08-05",
-        "limit": { "context": 128000, "output": 16384 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "gpt-oss-120b",
         "open_weights": false,
-        "reasoning": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          }
+        ],
+        "release_date": "2025-08-05",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "openai.gpt-oss-20b": {
+        "attachment": false,
+        "cost": {
+          "input": 0.07,
+          "output": 0.3
+        },
+        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
+        "family": "gpt-oss",
+        "id": "openai.gpt-oss-20b",
+        "last_updated": "2025-08-05",
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
+        "name": "gpt-oss-20b",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          }
+        ],
         "release_date": "2025-08-05",
         "structured_output": true,
         "temperature": true,
@@ -1065,15 +3034,31 @@
       },
       "openai.gpt-oss-20b-1:0": {
         "attachment": false,
-        "cost": { "input": 0.07, "output": 0.3 },
+        "cost": {
+          "input": 0.07,
+          "output": 0.3
+        },
+        "description": "Open-weight GPT model for self-hosted reasoning and instruction-following workloads",
         "family": "gpt-oss",
         "id": "openai.gpt-oss-20b-1:0",
         "last_updated": "2025-08-05",
-        "limit": { "context": 128000, "output": 16384 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "gpt-oss-20b",
         "open_weights": false,
-        "reasoning": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          }
+        ],
         "release_date": "2025-08-05",
         "structured_output": true,
         "temperature": true,
@@ -1081,12 +3066,22 @@
       },
       "openai.gpt-oss-safeguard-120b": {
         "attachment": false,
-        "cost": { "input": 0.15, "output": 0.6 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
         "family": "gpt-oss",
         "id": "openai.gpt-oss-safeguard-120b",
         "last_updated": "2025-10-29",
-        "limit": { "context": 128000, "output": 16384 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "GPT OSS Safeguard 120B",
         "open_weights": false,
         "reasoning": false,
@@ -1097,12 +3092,22 @@
       },
       "openai.gpt-oss-safeguard-20b": {
         "attachment": false,
-        "cost": { "input": 0.07, "output": 0.2 },
+        "cost": {
+          "input": 0.07,
+          "output": 0.2
+        },
+        "description": "Safety model for policy screening, moderation, and risk-aware routing workflows",
         "family": "gpt-oss",
         "id": "openai.gpt-oss-safeguard-20b",
         "last_updated": "2025-10-29",
-        "limit": { "context": 128000, "output": 16384 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "GPT OSS Safeguard 20B",
         "open_weights": false,
         "reasoning": false,
@@ -1113,13 +3118,23 @@
       },
       "qwen.qwen3-235b-a22b-2507-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.22, "output": 0.88 },
+        "cost": {
+          "input": 0.22,
+          "output": 0.88
+        },
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
         "family": "qwen",
         "id": "qwen.qwen3-235b-a22b-2507-v1:0",
         "knowledge": "2024-04",
         "last_updated": "2025-09-18",
-        "limit": { "context": 262144, "output": 131072 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Qwen3 235B A22B 2507",
         "open_weights": true,
         "reasoning": false,
@@ -1130,16 +3145,27 @@
       },
       "qwen.qwen3-32b-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.15, "output": 0.6 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
         "family": "qwen",
         "id": "qwen.qwen3-32b-v1:0",
         "knowledge": "2024-04",
         "last_updated": "2025-09-18",
-        "limit": { "context": 16384, "output": 16384 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 16384,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Qwen3 32B (dense)",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-09-18",
         "structured_output": true,
         "temperature": true,
@@ -1147,13 +3173,23 @@
       },
       "qwen.qwen3-coder-30b-a3b-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.15, "output": 0.6 },
+        "cost": {
+          "input": 0.15,
+          "output": 0.6
+        },
+        "description": "Qwen coding model for software agents, repository edits, and code reasoning",
         "family": "qwen",
         "id": "qwen.qwen3-coder-30b-a3b-v1:0",
         "knowledge": "2024-04",
         "last_updated": "2025-09-18",
-        "limit": { "context": 262144, "output": 131072 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 262144,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Qwen3 Coder 30B A3B Instruct",
         "open_weights": false,
         "reasoning": false,
@@ -1164,13 +3200,23 @@
       },
       "qwen.qwen3-coder-480b-a35b-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.22, "output": 1.8 },
+        "cost": {
+          "input": 0.22,
+          "output": 1.8
+        },
+        "description": "Qwen coding model for software agents, repository edits, and code reasoning",
         "family": "qwen",
         "id": "qwen.qwen3-coder-480b-a35b-v1:0",
         "knowledge": "2024-04",
         "last_updated": "2025-09-18",
-        "limit": { "context": 131072, "output": 65536 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Qwen3 Coder 480B A35B Instruct",
         "open_weights": true,
         "reasoning": false,
@@ -1181,15 +3227,26 @@
       },
       "qwen.qwen3-coder-next": {
         "attachment": false,
-        "cost": { "input": 0.22, "output": 1.8 },
+        "cost": {
+          "input": 0.22,
+          "output": 1.8
+        },
+        "description": "Qwen coding model for software agents, repository edits, and code reasoning",
         "family": "qwen",
         "id": "qwen.qwen3-coder-next",
         "last_updated": "2026-02-06",
-        "limit": { "context": 131072, "output": 65536 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 131072,
+          "output": 65536
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Qwen3 Coder Next",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-02-06",
         "structured_output": true,
         "temperature": true,
@@ -1197,12 +3254,22 @@
       },
       "qwen.qwen3-next-80b-a3b": {
         "attachment": false,
-        "cost": { "input": 0.14, "output": 1.4 },
+        "cost": {
+          "input": 0.14,
+          "output": 1.4
+        },
+        "description": "Qwen instruction model for multilingual chat, reasoning, and tool use",
         "family": "qwen",
         "id": "qwen.qwen3-next-80b-a3b",
         "last_updated": "2025-11-25",
-        "limit": { "context": 262000, "output": 262000 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 262000,
+          "output": 262000
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Qwen/Qwen3-Next-80B-A3B-Instruct",
         "open_weights": false,
         "reasoning": false,
@@ -1213,12 +3280,22 @@
       },
       "qwen.qwen3-vl-235b-a22b": {
         "attachment": true,
-        "cost": { "input": 0.3, "output": 1.5 },
+        "cost": {
+          "input": 0.3,
+          "output": 1.5
+        },
+        "description": "Qwen vision-language model for visual reasoning, documents, and agent tasks",
         "family": "qwen",
         "id": "qwen.qwen3-vl-235b-a22b",
         "last_updated": "2025-11-25",
-        "limit": { "context": 262000, "output": 262000 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 262000,
+          "output": 262000
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
         "open_weights": false,
         "reasoning": false,
@@ -1227,18 +3304,70 @@
         "temperature": true,
         "tool_call": true
       },
+      "us.anthropic.claude-fable-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 1,
+          "cache_write": 12.5,
+          "input": 10,
+          "output": 50
+        },
+        "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+        "family": "claude-fable",
+        "id": "us.anthropic.claude-fable-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-09",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Fable 5 (US)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-09",
+        "temperature": false,
+        "tool_call": true
+      },
       "us.anthropic.claude-haiku-4-5-20251001-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.1, "cache_write": 1.25, "input": 1, "output": 5 },
+        "cost": {
+          "cache_read": 0.1,
+          "cache_write": 1.25,
+          "input": 1,
+          "output": 5
+        },
+        "description": "Fast Claude model for responsive assistance, classification, and lightweight agents",
         "family": "claude-haiku",
         "id": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "knowledge": "2025-02-28",
         "last_updated": "2025-10-15",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Haiku 4.5 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-10-15",
         "structured_output": true,
         "temperature": true,
@@ -1246,32 +3375,73 @@
       },
       "us.anthropic.claude-opus-4-1-20250805-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 1.5, "cache_write": 18.75, "input": 15, "output": 75 },
+        "cost": {
+          "cache_read": 1.5,
+          "cache_write": 18.75,
+          "input": 15,
+          "output": 75
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
         "knowledge": "2025-03-31",
         "last_updated": "2025-08-05",
-        "limit": { "context": 200000, "output": 32000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 32000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.1 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-08-05",
+        "status": "deprecated",
         "temperature": true,
         "tool_call": true
       },
       "us.anthropic.claude-opus-4-5-20251101-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
         "knowledge": "2025-03-31",
         "last_updated": "2025-08-01",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.5 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-11-24",
         "structured_output": true,
         "temperature": true,
@@ -1279,16 +3449,38 @@
       },
       "us.anthropic.claude-opus-4-6-v1": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "High-end Claude for difficult coding, planning, and slower expert reasoning",
         "family": "claude-opus",
         "id": "us.anthropic.claude-opus-4-6-v1",
         "knowledge": "2025-05-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.6 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-05",
         "structured_output": true,
         "temperature": true,
@@ -1296,47 +3488,136 @@
       },
       "us.anthropic.claude-opus-4-7": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Flagship Claude model for deep reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "us.anthropic.claude-opus-4-7",
         "knowledge": "2026-01-31",
         "last_updated": "2026-04-16",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.7 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-04-16",
         "temperature": false,
         "tool_call": true
       },
       "us.anthropic.claude-opus-4-8": {
         "attachment": true,
-        "cost": { "cache_read": 0.5, "cache_write": 6.25, "input": 5, "output": 25 },
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Top Claude Opus tier for the hardest reasoning, coding, and long-horizon agents",
         "family": "claude-opus",
         "id": "us.anthropic.claude-opus-4-8",
+        "knowledge": "2026-01",
         "last_updated": "2026-05-28",
-        "limit": { "context": 1000000, "output": 128000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Opus 4.8 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
         "release_date": "2026-05-28",
+        "temperature": false,
+        "tool_call": true
+      },
+      "us.anthropic.claude-opus-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.5,
+          "cache_write": 6.25,
+          "input": 5,
+          "output": 25
+        },
+        "description": "Strongest Claude Opus model for coding, agents, and professional work",
+        "family": "claude-opus",
+        "id": "us.anthropic.claude-opus-5",
+        "knowledge": "2026-05",
+        "last_updated": "2026-07-24",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Opus 5 (US)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-07-24",
         "temperature": false,
         "tool_call": true
       },
       "us.anthropic.claude-sonnet-4-5-20250929-v1:0": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Balanced Claude model for coding, analysis, agent workflows, and cost control",
         "family": "claude-sonnet",
         "id": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "knowledge": "2025-07-31",
         "last_updated": "2025-09-29",
-        "limit": { "context": 200000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.5 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2025-09-29",
         "structured_output": true,
         "temperature": true,
@@ -1344,46 +3625,127 @@
       },
       "us.anthropic.claude-sonnet-4-6": {
         "attachment": true,
-        "cost": { "cache_read": 0.3, "cache_write": 3.75, "input": 3, "output": 15 },
+        "cost": {
+          "cache_read": 0.3,
+          "cache_write": 3.75,
+          "input": 3,
+          "output": 15
+        },
+        "description": "Claude workhorse for coding agents, careful analysis, and production cost control",
         "family": "claude-sonnet",
         "id": "us.anthropic.claude-sonnet-4-6",
         "knowledge": "2025-08-31",
         "last_updated": "2026-03-13",
-        "limit": { "context": 1000000, "output": 64000 },
-        "modalities": { "input": ["text", "image", "pdf"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 64000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
         "name": "Claude Sonnet 4.6 (US)",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "max"]
+          },
+          {
+            "min": 1024,
+            "type": "budget_tokens"
+          }
+        ],
         "release_date": "2026-02-17",
         "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
+      "us.anthropic.claude-sonnet-5": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "cache_write": 2.5,
+          "input": 2,
+          "output": 10
+        },
+        "description": "Everyday Claude agent model for coding, planning, browsing, and general work",
+        "family": "claude-sonnet",
+        "id": "us.anthropic.claude-sonnet-5",
+        "knowledge": "2026-01-31",
+        "last_updated": "2026-06-30",
+        "limit": {
+          "context": 1000000,
+          "output": 128000
+        },
+        "modalities": {
+          "input": ["text", "image", "pdf"],
+          "output": ["text"]
+        },
+        "name": "Claude Sonnet 5 (US)",
+        "open_weights": false,
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "toggle"
+          },
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh", "max"]
+          }
+        ],
+        "release_date": "2026-06-30",
+        "structured_output": true,
+        "temperature": false,
+        "tool_call": true
+      },
       "us.deepseek.r1-v1:0": {
         "attachment": false,
-        "cost": { "input": 1.35, "output": 5.4 },
+        "cost": {
+          "input": 1.35,
+          "output": 5.4
+        },
+        "description": "Classic open reasoning model for transparent math, coding, and deliberate problem solving",
         "family": "deepseek-thinking",
         "id": "us.deepseek.r1-v1:0",
         "knowledge": "2024-07",
         "last_updated": "2025-05-29",
-        "limit": { "context": 128000, "output": 32768 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 128000,
+          "output": 32768
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "DeepSeek-R1 (US)",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-01-20",
         "temperature": true,
         "tool_call": true
       },
       "us.meta.llama4-maverick-17b-instruct-v1:0": {
         "attachment": true,
-        "cost": { "input": 0.24, "output": 0.97 },
+        "cost": {
+          "input": 0.24,
+          "output": 0.97
+        },
+        "description": "Open multimodal Llama for strong reasoning with efficient everyday serving",
         "family": "llama",
         "id": "us.meta.llama4-maverick-17b-instruct-v1:0",
         "knowledge": "2024-08",
         "last_updated": "2025-04-05",
-        "limit": { "context": 1000000, "output": 16384 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 1000000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Llama 4 Maverick 17B Instruct (US)",
         "open_weights": true,
         "reasoning": false,
@@ -1393,13 +3755,23 @@
       },
       "us.meta.llama4-scout-17b-instruct-v1:0": {
         "attachment": true,
-        "cost": { "input": 0.17, "output": 0.66 },
+        "cost": {
+          "input": 0.17,
+          "output": 0.66
+        },
+        "description": "Open Llama with long-context vision for efficient multimodal agents",
         "family": "llama",
         "id": "us.meta.llama4-scout-17b-instruct-v1:0",
         "knowledge": "2024-08",
         "last_updated": "2025-04-05",
-        "limit": { "context": 3500000, "output": 16384 },
-        "modalities": { "input": ["text", "image"], "output": ["text"] },
+        "limit": {
+          "context": 3500000,
+          "output": 16384
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
         "name": "Llama 4 Scout 17B Instruct (US)",
         "open_weights": true,
         "reasoning": false,
@@ -1409,47 +3781,159 @@
       },
       "writer.palmyra-x4-v1:0": {
         "attachment": false,
-        "cost": { "input": 2.5, "output": 10 },
+        "cost": {
+          "input": 2.5,
+          "output": 10
+        },
+        "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
         "family": "palmyra",
         "id": "writer.palmyra-x4-v1:0",
         "last_updated": "2025-04-28",
-        "limit": { "context": 122880, "output": 8192 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 122880,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Palmyra X4",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-04-28",
         "temperature": true,
         "tool_call": true
       },
       "writer.palmyra-x5-v1:0": {
         "attachment": false,
-        "cost": { "input": 0.6, "output": 6 },
+        "cost": {
+          "input": 0.6,
+          "output": 6
+        },
+        "description": "Reasoning model for deliberate analysis, multi-step problem solving, and tool use",
         "family": "palmyra",
         "id": "writer.palmyra-x5-v1:0",
         "last_updated": "2025-04-28",
-        "limit": { "context": 1040000, "output": 8192 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 1040000,
+          "output": 8192
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "Palmyra X5",
         "open_weights": false,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-04-28",
+        "temperature": true,
+        "tool_call": true
+      },
+      "xai.grok-4.3": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.2,
+          "input": 1.25,
+          "output": 2.5
+        },
+        "description": "xAI's default Grok for chat, coding, agentic tools, and lower hallucination risk",
+        "family": "grok",
+        "id": "xai.grok-4.3",
+        "last_updated": "2026-06-28",
+        "limit": {
+          "context": 1000000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "name": "Grok 4.3",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["none", "low", "medium", "high"]
+          }
+        ],
+        "release_date": "2026-04-17",
+        "structured_output": true,
+        "temperature": true,
+        "tool_call": true
+      },
+      "xai.grok-4.6": {
+        "attachment": true,
+        "cost": {
+          "cache_read": 0.55,
+          "input": 2.2,
+          "output": 6.6
+        },
+        "description": "xAI's frontier model for long-running agents, coding, knowledge work, and visual projects",
+        "family": "grok",
+        "id": "xai.grok-4.6",
+        "knowledge": "2026-02-01",
+        "last_updated": "2026-08-18",
+        "limit": {
+          "context": 500000,
+          "output": 500000
+        },
+        "modalities": {
+          "input": ["text", "image"],
+          "output": ["text"]
+        },
+        "name": "Grok 4.6",
+        "open_weights": false,
+        "provider": {
+          "api": "https://bedrock-mantle.${AWS_REGION}.api.aws/openai/v1",
+          "npm": "@ai-sdk/amazon-bedrock/mantle",
+          "shape": "responses"
+        },
+        "reasoning": true,
+        "reasoning_options": [
+          {
+            "type": "effort",
+            "values": ["low", "medium", "high", "xhigh"]
+          }
+        ],
+        "release_date": "2026-08-12",
+        "structured_output": true,
         "temperature": true,
         "tool_call": true
       },
       "zai.glm-4.7": {
         "attachment": false,
-        "cost": { "input": 0.6, "output": 2.2 },
+        "cost": {
+          "input": 0.6,
+          "output": 2.2
+        },
+        "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
         "family": "glm",
         "id": "zai.glm-4.7",
-        "interleaved": { "field": "reasoning_content" },
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "knowledge": "2025-04",
         "last_updated": "2025-12-22",
-        "limit": { "context": 204800, "output": 131072 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 204800,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "GLM-4.7",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2025-12-22",
         "structured_output": true,
         "temperature": true,
@@ -1457,16 +3941,27 @@
       },
       "zai.glm-4.7-flash": {
         "attachment": false,
-        "cost": { "input": 0.07, "output": 0.4 },
+        "cost": {
+          "input": 0.07,
+          "output": 0.4
+        },
+        "description": "Efficient GLM model for fast reasoning, coding, and agent workflows",
         "family": "glm-flash",
         "id": "zai.glm-4.7-flash",
         "knowledge": "2025-04",
         "last_updated": "2026-01-19",
-        "limit": { "context": 200000, "output": 131072 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 200000,
+          "output": 131072
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "GLM-4.7-Flash",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-01-19",
         "structured_output": true,
         "temperature": true,
@@ -1474,16 +3969,29 @@
       },
       "zai.glm-5": {
         "attachment": false,
-        "cost": { "input": 1, "output": 3.2 },
+        "cost": {
+          "input": 1,
+          "output": 3.2
+        },
+        "description": "Flagship GLM model for hybrid reasoning, coding, and agentic engineering",
         "family": "glm",
         "id": "zai.glm-5",
-        "interleaved": { "field": "reasoning_content" },
+        "interleaved": {
+          "field": "reasoning_content"
+        },
         "last_updated": "2026-03-18",
-        "limit": { "context": 202752, "output": 101376 },
-        "modalities": { "input": ["text"], "output": ["text"] },
+        "limit": {
+          "context": 202752,
+          "output": 101376
+        },
+        "modalities": {
+          "input": ["text"],
+          "output": ["text"]
+        },
         "name": "GLM-5",
         "open_weights": true,
         "reasoning": true,
+        "reasoning_options": [],
         "release_date": "2026-03-18",
         "structured_output": true,
         "temperature": true,

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -309,22 +309,24 @@ export function getModelProfile(modelId: string): ModelProfile {
 
     case "openai": {
       // OpenAI models on Bedrock support tool choice AND the OpenAI-style
-      // `reasoning_effort` parameter (CLI-verified: low | medium | high work;
-      // `minimal` is OpenAI-only; `max` is rejected).
+      // `reasoning_effort` parameter (CLI-verified: low | medium | high work
+      // on gpt-oss; `minimal` is OpenAI-only; `max` is rejected).
       //
       // Temperature support varies by model (via models.dev):
       // - gpt-oss models: accept temperature
       // - gpt-5.x and gpt-5.x-luna/sol/terra: reject temperature
       //
-      // gpt-5.x-luna variants (Luna 5.6, etc.) do NOT support reasoning_effort
-      // despite being OpenAI models on Bedrock.
+      // CLI-verified via `aws bedrock-runtime converse` (2026-08-22): ALL
+      // gpt-5.6 named variants (Luna, Sol, Terra) reject reasoning_effort
+      // with "unknown_parameter", not just Luna. models.dev reports
+      // `reasoning: true` for all three, which is misleading for Bedrock's
+      // actual behavior -- do not trust that flag for -luna/-sol/-terra IDs.
       const isRejectsTemperature =
         modelId.includes("gpt-5.4") || modelId.includes("gpt-5.5") || modelId.includes("gpt-5.6");
 
-      const isSupportsReasoningEffort =
-        !modelId.includes("gpt-5.6-luna") &&
-        !modelId.includes("gpt-5.5-luna") &&
-        !modelId.includes("gpt-5.4-luna");
+      const isNamedVariant =
+        modelId.includes("-luna") || modelId.includes("-sol") || modelId.includes("-terra");
+      const isSupportsReasoningEffort = !isNamedVariant;
 
       return {
         requiresAdaptiveThinking: false,

--- a/src/profiles.ts
+++ b/src/profiles.ts
@@ -173,10 +173,11 @@ export function getModelProfile(modelId: string): ModelProfile {
     case "anthropic": {
       // Claude models support tool choice and prompt caching
       // Extended thinking is supported by Claude Opus 4+, Sonnet 4+, Sonnet 3.7,
-      // and Haiku 4.5
-      const supportsThinking =
+      // Sonnet 5, and Haiku 4.5
+      const isSupportsThinking =
         modelId.includes("opus-4") ||
         modelId.includes("sonnet-4") ||
+        modelId.includes("sonnet-5") ||
         modelId.includes("sonnet-3-7") ||
         modelId.includes("sonnet-3.7") ||
         modelId.includes("haiku-4-5") ||
@@ -192,12 +193,13 @@ export function getModelProfile(modelId: string): ModelProfile {
 
       // Claude models with extended thinking have issues with cachePoint after toolResult
       // When extended thinking is enabled, cachePoint should only be added to messages without toolResult
-      const supportsCachingWithToolResults = !supportsThinking;
+      const isSupportsCachingWithToolResults = !isSupportsThinking;
 
-      // output_config.effort is supported on Claude Opus 4.8, 4.7, 4.6, 4.5, and Sonnet 4.6.
+      // output_config.effort is supported on Claude Opus 4.8, 4.7, 4.6, and 4.5, and Sonnet 4.6.
+      // Sonnet 5 does NOT support output_config.effort (uses adaptive thinking only).
       // The available levels vary by model (see supportsMaxEffort for the full breakdown).
-      // Reference: https://docs.aws.amazon.com/bedrock/latest/userguide/claude-messages-adaptive-thinking.html
-      const supportsThinkingEffort =
+      // Reference: https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+      const isSupportsThinkingEffort =
         normalizedId.includes("opus-4-8") ||
         normalizedId.includes("opus-4-7") ||
         normalizedId.includes("opus-4-6") ||
@@ -206,36 +208,45 @@ export function getModelProfile(modelId: string): ModelProfile {
 
       // "max" effort level is available on Opus 4.8, 4.7, and 4.6.
       // "xhigh" is additionally available on Opus 4.8 and 4.7 (covered by requiresAdaptiveThinking).
-      // Sonnet 4.6 only gets low/medium/high — AWS Bedrock docs confirm that "max"
+      // Sonnet 4.6 and Sonnet 5 only get low/medium/high — AWS Bedrock docs confirm that "max"
       // is restricted to Opus 4.6 in the adaptive thinking context and returns an error on other models.
-      const supportsMaxEffort =
+      const isSupportsMaxEffort =
         normalizedId.includes("opus-4-8") ||
         normalizedId.includes("opus-4-7") ||
         normalizedId.includes("opus-4-6");
 
-      // CLI-verified: Opus 4.7 and 4.8 reject `thinking.type="enabled"` and require
+      // CLI-verified: Opus 4.7, 4.8, and Sonnet 5 reject `thinking.type="enabled"` and require
       // `thinking.type="adaptive"` (with no budget_tokens). All other Claude
       // models still use enabled+budget.
-      const requiresAdaptiveThinking = modelId.includes("opus-4-7") || modelId.includes("opus-4-8");
+      const requiresAdaptiveThinking =
+        modelId.includes("opus-4-7") ||
+        modelId.includes("opus-4-8") ||
+        modelId.includes("sonnet-5");
 
-      // CLI-verified: Opus 4.7 and 4.8 reject requests that include the `temperature`
-      // inference parameter (Bedrock returns a ValidationException). All other
-      // Claude models still accept temperature.
-      const temperatureDeprecated = modelId.includes("opus-4-7") || modelId.includes("opus-4-8");
+      // CLI-verified via models.dev: Opus 4.7, 4.8, Opus 5, Sonnet 5, and Fable 5
+      // reject requests that include the `temperature` inference parameter (Bedrock returns
+      // a ValidationException). All other Claude models still accept temperature.
+      // Note: users can override this with bedrock.temperature.override setting if auto-detection fails.
+      const isTemperatureDeprecated =
+        modelId.includes("opus-4-7") ||
+        modelId.includes("opus-4-8") ||
+        modelId.includes("opus-5") ||
+        modelId.includes("sonnet-5") ||
+        modelId.includes("fable-5");
 
       return {
         requiresAdaptiveThinking,
         requiresInterleavedThinkingHeader,
-        supports1MContext: supports1MContext(modelId),
-        supportsCachingWithToolResults,
-        supportsMaxEffort,
+        supports1MContext: is1MContextSupported(modelId),
+        supportsCachingWithToolResults: isSupportsCachingWithToolResults,
+        supportsMaxEffort: isSupportsMaxEffort,
         supportsPromptCaching: true,
         supportsReasoningEffort: false, // Anthropic uses thinking.* / output_config.effort, not reasoning_effort
-        supportsThinking,
-        supportsThinkingEffort,
+        supportsThinking: isSupportsThinking,
+        supportsThinkingEffort: isSupportsThinkingEffort,
         supportsToolChoice: true,
         supportsToolResultStatus: true, // Claude models support status field in tool results
-        temperatureDeprecated,
+        temperatureDeprecated: isTemperatureDeprecated,
         toolResultFormat: "text",
       };
     }
@@ -297,9 +308,24 @@ export function getModelProfile(modelId: string): ModelProfile {
     }
 
     case "openai": {
-      // OpenAI gpt-oss models support tool choice AND the OpenAI-style
+      // OpenAI models on Bedrock support tool choice AND the OpenAI-style
       // `reasoning_effort` parameter (CLI-verified: low | medium | high work;
       // `minimal` is OpenAI-only; `max` is rejected).
+      //
+      // Temperature support varies by model (via models.dev):
+      // - gpt-oss models: accept temperature
+      // - gpt-5.x and gpt-5.x-luna/sol/terra: reject temperature
+      //
+      // gpt-5.x-luna variants (Luna 5.6, etc.) do NOT support reasoning_effort
+      // despite being OpenAI models on Bedrock.
+      const isRejectsTemperature =
+        modelId.includes("gpt-5.4") || modelId.includes("gpt-5.5") || modelId.includes("gpt-5.6");
+
+      const isSupportsReasoningEffort =
+        !modelId.includes("gpt-5.6-luna") &&
+        !modelId.includes("gpt-5.5-luna") &&
+        !modelId.includes("gpt-5.4-luna");
+
       return {
         requiresAdaptiveThinking: false,
         requiresInterleavedThinkingHeader: false,
@@ -307,12 +333,12 @@ export function getModelProfile(modelId: string): ModelProfile {
         supportsCachingWithToolResults: false,
         supportsMaxEffort: false,
         supportsPromptCaching: false,
-        supportsReasoningEffort: true,
+        supportsReasoningEffort: isSupportsReasoningEffort,
         supportsThinking: false,
         supportsThinkingEffort: false,
         supportsToolChoice: true,
         supportsToolResultStatus: false,
-        temperatureDeprecated: false,
+        temperatureDeprecated: isRejectsTemperature,
         toolResultFormat: "text",
       };
     }
@@ -339,12 +365,12 @@ export function getModelProfile(modelId: string): ModelProfile {
  * @param enable1MContext Whether to enable 1M context for supported models (default: false)
  * @returns Token limits with maxInputTokens and maxOutputTokens
  */
-export function getModelTokenLimits(modelId: string, enable1MContext = false): ModelTokenLimits {
+export function getModelTokenLimits(modelId: string, is1MContextEnabled = false): ModelTokenLimits {
   const normalizedModelId = normalizeModelId(modelId);
 
   // Claude models have specific token limits based on model family
   if (normalizedModelId.startsWith("anthropic.claude")) {
-    return getClaudeTokenLimits(normalizedModelId, enable1MContext);
+    return getClaudeTokenLimits(normalizedModelId, is1MContextEnabled);
   }
 
   // Default for unknown models
@@ -406,7 +432,7 @@ export function requires1MContextBetaHeader(modelId: string): boolean {
  */
 function getClaudeTokenLimits(
   normalizedModelId: string,
-  enable1MContext: boolean,
+  is1MContextEnabled: boolean,
 ): ModelTokenLimits {
   // Claude Opus 4.8: always 1M context, 128K max output.
   if (normalizedModelId.includes("opus-4-8")) {
@@ -422,9 +448,17 @@ function getClaudeTokenLimits(
   // Claude Opus 4.6: 200K context (or 1M with setting enabled), 128K max output.
   if (normalizedModelId.includes("opus-4-6")) {
     return {
-      maxInputTokens: (enable1MContext ? 1_000_000 : 200_000) - 128_000,
+      maxInputTokens: (is1MContextEnabled ? 1_000_000 : 200_000) - 128_000,
       maxOutputTokens: 128_000,
     };
+  }
+
+  // Claude Sonnet 5: always 1M context (default), 128K output.
+  // 1M is the standard context window for this model — no beta header needed.
+  // Uses new tokenizer: ~30% more tokens than Sonnet 4.6 for same text.
+  // Reference: https://platform.claude.com/docs/en/about-claude/models/whats-new-sonnet-5
+  if (normalizedModelId.includes("sonnet-5")) {
+    return { maxInputTokens: 1_000_000 - 128_000, maxOutputTokens: 128_000 };
   }
 
   // Claude Sonnet 4.6: always 1M context (default), 64K output.
@@ -436,7 +470,7 @@ function getClaudeTokenLimits(
   // Claude Sonnet 4.5 and 4: 200K context (or 1M with setting enabled), 64K output.
   if (normalizedModelId.includes("sonnet-4")) {
     return {
-      maxInputTokens: (enable1MContext ? 1_000_000 : 200_000) - 64_000,
+      maxInputTokens: (is1MContextEnabled ? 1_000_000 : 200_000) - 64_000,
       maxOutputTokens: 64_000,
     };
   }
@@ -492,14 +526,15 @@ function getClaudeTokenLimits(
 
 /**
  * Check if a model supports 1M context window
- * Claude Opus 4.7 and 4.8 (always), Opus 4.6, Sonnet 4.6, and Sonnet 4.x models support
+ * Claude Opus 4.7 and 4.8 (always), Opus 4.6, Sonnet 5, Sonnet 4.6, and Sonnet 4.x models support
  * extended 1M context.
  */
-function supports1MContext(modelId: string): boolean {
+function is1MContextSupported(modelId: string): boolean {
   const normalizedModelId = normalizeModelId(modelId);
   return (
     normalizedModelId.includes("opus-4-7") ||
     normalizedModelId.includes("opus-4-8") ||
+    normalizedModelId.includes("sonnet-5") ||
     requires1MContextBetaHeader(normalizedModelId)
   );
 }

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,21 +8,21 @@
 
 import { ModelModality } from "@aws-sdk/client-bedrock";
 import type {
-  ConverseStreamCommandInput,
-  Message,
-  SystemContentBlock,
-  ToolConfiguration,
+    ConverseStreamCommandInput,
+    Message,
+    SystemContentBlock,
+    ToolConfiguration,
 } from "@aws-sdk/client-bedrock-runtime";
 import { inspect, MIMEType } from "node:util";
 import type {
-  CancellationToken,
-  LanguageModelChatInformation,
-  LanguageModelChatMessage,
-  LanguageModelChatProvider,
-  LanguageModelConfigurationSchema,
-  LanguageModelResponsePart,
-  LanguageModelResponsePart2,
-  Progress,
+    CancellationToken,
+    LanguageModelChatInformation,
+    LanguageModelChatMessage,
+    LanguageModelChatProvider,
+    LanguageModelConfigurationSchema,
+    LanguageModelResponsePart,
+    LanguageModelResponsePart2,
+    Progress,
 } from "vscode";
 import * as vscode from "vscode";
 
@@ -33,18 +33,19 @@ import { convertTools } from "./converters/tools";
 import { logger } from "./logger";
 import { loadModelsDevData as loadModelsDevelopmentData } from "./models-dev";
 import {
-  getModelProfile,
-  getModelTokenLimits,
-  normalizeModelId,
-  requires1MContextBetaHeader,
+    getModelProfile,
+    getModelTokenLimits,
+    normalizeModelId,
+    requires1MContextBetaHeader,
 } from "./profiles";
 import { getBedrockSettings, type ReasoningEffort, type ThinkingEffort } from "./settings";
 import { StreamProcessor, type ThinkingBlock } from "./stream-processor";
 import type {
-  AuthConfig,
-  AuthMethod,
-  BedrockModelSummary,
-  ModelsDevMap as ModelsDevelopmentMap,
+    AuthConfig,
+    AuthMethod,
+    BedrockModelSummary,
+    ModelsDevEntry as ModelsDevelopmentEntry,
+    ModelsDevMap as ModelsDevelopmentMap,
 } from "./types";
 import { validateBedrockMessages } from "./validation";
 
@@ -589,15 +590,11 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // models (temperatureDeprecated, tool_call support).
       const modelsDevelopmentMap = loadModelsDevelopmentData();
       const normalizedBaseId = normalizeModelId(baseModelId);
-      const chatDevelopmentEntry =
-        modelsDevelopmentMap.get(baseModelId) ??
-        modelsDevelopmentMap.get(normalizedBaseId) ??
-        (() => {
-          // Full-scan fallback: strip version suffix and match by normalized prefix
-          for (const [key, entry] of modelsDevelopmentMap) {
-            if (normalizeModelId(key) === normalizedBaseId) return entry;
-          }
-        })();
+      const chatDevelopmentEntry = resolveModelsDevelopmentEntry(
+        baseModelId,
+        normalizedBaseId,
+        modelsDevelopmentMap,
+      );
 
       // temperatureDeprecated: profiles.ts is authoritative; fall back to
       // models.dev `temperature: false` for models not yet enumerated.
@@ -923,18 +920,59 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       return 0;
     };
 
+    // Image MIME types that convertMessages actually forwards to Bedrock as
+    // image content blocks (see isImageDataPart in converters/messages.ts).
+    const SUPPORTED_IMAGE_MIME_TYPES = new Set(["image/gif", "image/jpeg", "image/png", "image/webp"]);
+
+    // Estimate the token cost of a single image data part. convertMessages
+    // sends PNG/JPEG/GIF/WebP LanguageModelDataPart values to Bedrock as
+    // image blocks, but images don't tokenize like text -- counting their
+    // raw byte length via char_count/4 would wildly overcount, while
+    // returning 0 (the previous behavior) undercounts and can cause context
+    // overflows to go undetected. Without decoding pixel dimensions, use a
+    // conservative estimate based on the base64-encoded payload size, which
+    // approximates Claude's vision token cost of roughly
+    // (width * height) / 750 for typical photo/screenshot compression ratios.
+    const estimateImageTokens = (dataLength: number): number => {
+      const base64Length = Math.ceil(dataLength / 3) * 4;
+      return Math.ceil(base64Length / 100);
+    };
+
+    // Sum image token costs (bypasses the char_count/4 + multiplier path
+    // used for text, since image tokenization doesn't scale the same way).
+    const estimateImagePartTokens = (part: unknown): number => {
+      if (
+        part instanceof vscode.LanguageModelDataPart &&
+        SUPPORTED_IMAGE_MIME_TYPES.has(part.mimeType)
+      ) {
+        return estimateImageTokens(part.data.length);
+      }
+      if (part instanceof vscode.LanguageModelToolResultPart) {
+        return part.content.reduce(
+          (sum: number, inner: unknown) => sum + estimateImagePartTokens(inner),
+          0,
+        );
+      }
+      return 0;
+    };
+
     // Fallback estimation function with model-aware token multipliers
     const estimateTokens = (input: LanguageModelChatMessage | string, modelId: string): number => {
       const multiplier = getTokenMultiplier(modelId);
-      const charLength =
-        typeof input === "string"
-          ? input.length
-          : input.content.reduce(
-              (sum: number, part: unknown) => sum + estimatePartCharLength(part),
-              0,
-            );
+      if (typeof input === "string") {
+        return Math.ceil((input.length / 4) * multiplier);
+      }
 
-      return Math.ceil((charLength / 4) * multiplier);
+      const charLength = input.content.reduce(
+        (sum: number, part: unknown) => sum + estimatePartCharLength(part),
+        0,
+      );
+      const imageTokens = input.content.reduce(
+        (sum: number, part: unknown) => sum + estimateImagePartTokens(part),
+        0,
+      );
+
+      return Math.ceil((charLength / 4) * multiplier) + imageTokens;
     };
 
     try {
@@ -1143,10 +1181,14 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
     // Resolve the models.dev entry for live capability data.
     // normalizeModelId strips regional prefixes (us., eu., global., etc.) so we
-    // can match against the bare model IDs stored in models.dev.
+    // can match against the bare model IDs stored in models.dev. Falls back to
+    // a full-map scan by normalized ID (same as resolveModelLimits and the
+    // chatDevelopmentEntry lookup in provideLanguageModelChatResponse) because
+    // models.dev entries can be stored under a different regional prefix than
+    // the one currently selected (e.g. picker uses `us.` but models.dev only
+    // has a `global.` entry for the same base model).
     const normalizedId = normalizeModelId(modelId);
-    const developmentEntry =
-      modelsDevelopmentMap.get(modelId) ?? modelsDevelopmentMap.get(normalizedId);
+    const developmentEntry = resolveModelsDevelopmentEntry(modelId, normalizedId, modelsDevelopmentMap);
 
     // ── Context size picker ────────────────────────────────────────────────
     // Only shown for models where 1M context is an *optional* beta-header opt-in
@@ -1849,8 +1891,11 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       contextK >= 1000 ? `${(contextK / 1000).toFixed(0)}M tokens` : `${contextK}K tokens`;
 
     let thinkingLine: string | undefined;
-    if (profile.requiresAdaptiveThinking) {
+    if (profile.requiresAdaptiveThinking && profile.supportsThinkingEffort) {
       thinkingLine = "Thinking: adaptive only (uses output_config.effort)";
+    } else if (profile.requiresAdaptiveThinking) {
+      // Sonnet 5: adaptive thinking without output_config.effort support.
+      thinkingLine = "Thinking: adaptive only";
     } else if (profile.supportsThinkingEffort) {
       thinkingLine = "Thinking: enabled+budget_tokens with effort setting";
     } else if (profile.supportsThinking) {
@@ -2274,16 +2319,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     // so a direct + normalized lookup may still miss entries stored under a
     // different prefix variant. Fall back to a full-map scan by normalized ID.
     const normalizedId = normalizeModelId(modelId);
-    let developmentEntry =
-      modelsDevelopmentMap.get(modelId) ?? modelsDevelopmentMap.get(normalizedId);
-    if (!developmentEntry) {
-      for (const [key, entry] of modelsDevelopmentMap) {
-        if (normalizeModelId(key) === normalizedId) {
-          developmentEntry = entry;
-          break;
-        }
-      }
-    }
+    const developmentEntry = resolveModelsDevelopmentEntry(modelId, normalizedId, modelsDevelopmentMap);
 
     if (developmentEntry) {
       const developmentOutput = developmentEntry.limit.output;
@@ -2327,6 +2363,38 @@ function isNamedGpt5Variant(baseModelId: string): boolean {
   return (
     baseModelId.includes("-luna") || baseModelId.includes("-sol") || baseModelId.includes("-terra")
   );
+}
+
+/**
+ * Look up a models.dev entry for a model ID, trying (in order):
+ * 1. Exact match on the raw model ID.
+ * 2. Exact match on the normalized ID (regional prefix stripped).
+ * 3. A full-map scan comparing normalized keys against the normalized ID.
+ *
+ * Step 3 is necessary because models.dev entries can be stored under a
+ * different regional prefix (e.g. `global.`) than the one currently in use
+ * (e.g. `us.`) for the same base model -- a direct or single normalized
+ * lookup can miss the entry entirely. Shared by every call site that reads
+ * models.dev capability/limit data (buildConfigurationSchema,
+ * resolveModelLimits, provideLanguageModelChatResponse) so they can never
+ * drift out of sync on how models.dev entries are resolved.
+ */
+function resolveModelsDevelopmentEntry(
+  modelId: string,
+  normalizedId: string,
+  modelsDevelopmentMap: ModelsDevelopmentMap,
+): ModelsDevelopmentEntry | undefined {
+  const direct = modelsDevelopmentMap.get(modelId) ?? modelsDevelopmentMap.get(normalizedId);
+  if (direct) {
+    return direct;
+  }
+
+  for (const [key, entry] of modelsDevelopmentMap) {
+    if (normalizeModelId(key) === normalizedId) {
+      return entry;
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -2375,18 +2443,25 @@ const UNSUPPORTED_PARAMETER_PATTERNS = [
  * mutating it in place. Returns true if the leaf key was found and removed.
  */
 function didDeleteDottedPath(root: Record<string, unknown>, dottedPath: string): boolean {
-  const [rootKey, ...pathRest] = dottedPath.split(".");
+  const pathParts = dottedPath.split(".");
+  const [rootKey, ...pathRest] = pathParts;
   const rootValue = root[rootKey];
   if (pathRest.length === 0 || !rootValue || typeof rootValue !== "object") {
     return false;
   }
 
+  // Walk down to the leaf's parent, keeping track of each ancestor object and
+  // the key used to reach it so we can prune now-empty ancestors afterward.
+  const ancestors: { key: string; object: Record<string, unknown> }[] = [
+    { key: rootKey, object: root },
+  ];
   let cursor: Record<string, unknown> = rootValue as Record<string, unknown>;
   for (let index = 0; index < pathRest.length - 1; index++) {
     const next = cursor[pathRest[index]];
     if (!next || typeof next !== "object") {
       return false;
     }
+    ancestors.push({ key: pathRest[index], object: cursor });
     cursor = next as Record<string, unknown>;
   }
 
@@ -2395,6 +2470,20 @@ function didDeleteDottedPath(root: Record<string, unknown>, dottedPath: string):
     return false;
   }
   delete cursor[leafKey];
+
+  // Prune now-empty parent objects (e.g. an emptied `output_config` or
+  // `thinking` object) so the retry request doesn't resend an empty object
+  // that Bedrock may reject with the same or a different validation error.
+  let emptyChild: Record<string, unknown> = cursor;
+  for (let index = ancestors.length - 1; index >= 0; index--) {
+    if (Object.keys(emptyChild).length > 0) {
+      break;
+    }
+    const { key, object: parent } = ancestors[index];
+    delete parent[key];
+    emptyChild = parent;
+  }
+
   return true;
 }
 

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -1,7 +1,14 @@
+/* eslint-disable unicorn/consistent-boolean-name -- provider parameters match VS Code and settings API names */
+/* eslint-disable unicorn/consistent-class-member-order -- lifecycle event is exposed before private implementation state */
+/* eslint-disable unicorn/consistent-function-scoping -- helper remains local to the token-counting workflow */
+/* eslint-disable unicorn/no-break-in-nested-loop -- message scanning intentionally skips unsupported parts */
+/* eslint-disable unicorn/prefer-includes-over-repeated-comparisons -- protocol checks are intentionally explicit */
+/* eslint-disable unicorn/prefer-simple-condition-first -- condition order preserves short-circuit safety */
+/* eslint-disable unicorn/prefer-ternary -- branches contain logging and control-flow side effects */
+
 import { ModelModality } from "@aws-sdk/client-bedrock";
 import type {
   ConverseStreamCommandInput,
-  CountTokensCommandInput,
   Message,
   SystemContentBlock,
   ToolConfiguration,
@@ -21,10 +28,10 @@ import * as vscode from "vscode";
 
 import { getRegionPrefix } from "./aws-partition";
 import { BedrockAPIClient, ListFoundationModelsDeniedError } from "./bedrock-client";
-import { convertMessages, stripThinkingContent } from "./converters/messages";
+import { convertMessages } from "./converters/messages";
 import { convertTools } from "./converters/tools";
 import { logger } from "./logger";
-import { loadModelsDevData } from "./models-dev";
+import { loadModelsDevData as loadModelsDevelopmentData } from "./models-dev";
 import {
   getModelProfile,
   getModelTokenLimits,
@@ -33,7 +40,12 @@ import {
 } from "./profiles";
 import { getBedrockSettings, type ReasoningEffort, type ThinkingEffort } from "./settings";
 import { StreamProcessor, type ThinkingBlock } from "./stream-processor";
-import type { AuthConfig, AuthMethod, BedrockModelSummary, ModelsDevMap } from "./types";
+import type {
+  AuthConfig,
+  AuthMethod,
+  BedrockModelSummary,
+  ModelsDevMap as ModelsDevelopmentMap,
+} from "./types";
 import { validateBedrockMessages } from "./validation";
 
 type PickerLanguageModelChatInformation = LanguageModelChatInformation & {
@@ -57,7 +69,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
   private chatEndpoints: { model: string; modelMaxPromptTokens: number }[] = [];
   private readonly client: BedrockAPIClient;
-  /** Tracks whether the initial model fetch has completed (for avoiding startup feedback loops) */
+  /**
+  Tracks whether the initial model fetch has completed (for avoiding startup feedback loops)
+  */
   private initialFetchComplete = false;
   private lastThinkingBlock?: ThinkingBlock;
   private readonly streamProcessor: StreamProcessor;
@@ -124,7 +138,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         await vscode.commands.executeCommand("bedrock.manage");
         // Return empty array - user will need to refresh after configuring
         return [];
-      } else if (action !== "Use Default Credentials") {
+      }
+      if (action !== "Use Default Credentials") {
         // User cancelled
         return [];
       }
@@ -162,7 +177,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         ): Promise<LanguageModelChatInformation[]> => {
           progress?.report({ message: "Fetching model list..." });
 
-          const [models, apiProfileIds, modelsDevMap] = await Promise.all([
+          const [models, apiProfileIds, modelsDevelopmentMap] = await Promise.all([
             this.client.fetchModels(abortController.signal),
             this.client.fetchInferenceProfiles(abortController.signal),
             // Fetch models.dev data in parallel — provides live token limits, capability flags,
@@ -177,7 +192,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           }
 
           // Fetch application inference profiles after we have foundation models
-          const applicationProfiles = await this.client.fetchApplicationInferenceProfiles(
+          const appProfiles = await this.client.fetchApplicationInferenceProfiles(
             models,
             abortController.signal,
           );
@@ -233,14 +248,14 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             const limits = this.resolveModelLimits(
               modelIdToUse,
               settings.context1M.enabled,
-              modelsDevMap,
+              modelsDevelopmentMap,
             );
             const maxInput = limits.maxInputTokens;
             const maxOutput = limits.maxOutputTokens;
             // Use models.dev modalities when available (more accurate than Bedrock API)
-            const devEntry = modelsDevMap.get(modelIdToUse);
-            const vision = devEntry
-              ? (devEntry.modalities?.input?.includes("image") ?? false)
+            const developmentEntry = modelsDevelopmentMap.get(modelIdToUse);
+            const isVision = developmentEntry
+              ? (developmentEntry.modalities?.input?.includes("image") ?? false)
               : m.inputModalities.includes(ModelModality.IMAGE);
 
             // Classify the invocation route so the tooltip can state it plainly.
@@ -257,7 +272,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             const modelInfo: PickerLanguageModelChatInformation = {
               capabilities: {
                 agentMode: true,
-                imageInput: vision,
+                imageInput: isVision,
                 // Advertise tool calling for all models: profiles.ts correctly gates
                 // tool use at request time via supportsToolChoice, but advertising
                 // false here would break agent mode for any model not yet enumerated.
@@ -266,9 +281,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
               configurationSchema: this.buildConfigurationSchema(
                 modelIdToUse,
                 modelProfile,
-                modelsDevMap,
+                modelsDevelopmentMap,
               ),
-              detail: this.formatDetail(modelIdToUse, maxInput, maxOutput, vision),
+              detail: this.formatDetail(modelIdToUse, maxInput, maxOutput, isVision),
               family: "bedrock",
               id: modelIdToUse,
               isUserSelectable: true,
@@ -281,7 +296,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
                 modelId: modelIdToUse,
                 providerName: m.providerName,
                 route,
-                vision,
+                vision: isVision,
               }),
               version: "1.0.0",
             };
@@ -290,10 +305,10 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
           // Add application inference profiles
           progress?.report({
-            message: `Processing ${applicationProfiles.length} application profiles...`,
+            message: `Processing ${appProfiles.length} application profiles...`,
           });
 
-          for (const profile of applicationProfiles) {
+          for (const profile of appProfiles) {
             // Filter profiles similar to foundation models - must support streaming and text output
             if (
               !profile.responseStreamingSupported ||
@@ -310,28 +325,28 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             const limits = this.resolveModelLimits(
               modelIdForLimits,
               settings.context1M.enabled,
-              modelsDevMap,
+              modelsDevelopmentMap,
             );
             const maxInput = limits.maxInputTokens;
             const maxOutput = limits.maxOutputTokens;
-            const devEntryForProfile = modelsDevMap.get(modelIdForLimits);
-            const vision = devEntryForProfile
-              ? (devEntryForProfile.modalities?.input?.includes("image") ?? false)
+            const developmentEntryForProfile = modelsDevelopmentMap.get(modelIdForLimits);
+            const isVision = developmentEntryForProfile
+              ? (developmentEntryForProfile.modalities?.input?.includes("image") ?? false)
               : profile.inputModalities.includes(ModelModality.IMAGE);
 
             const appProfileModelProfile = getModelProfile(modelIdForLimits);
             const profileInfo: PickerLanguageModelChatInformation = {
               capabilities: {
                 agentMode: true,
-                imageInput: vision,
+                imageInput: isVision,
                 toolCalling: true,
               },
               configurationSchema: this.buildConfigurationSchema(
                 modelIdForLimits,
                 appProfileModelProfile,
-                modelsDevMap,
+                modelsDevelopmentMap,
               ),
-              detail: this.formatDetail(modelIdForLimits, maxInput, maxOutput, vision),
+              detail: this.formatDetail(modelIdForLimits, maxInput, maxOutput, isVision),
               family: "bedrock",
               id: profile.modelArn,
               isUserSelectable: true,
@@ -344,7 +359,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
                 modelId: modelIdForLimits,
                 providerName: profile.providerName,
                 route: "Application inference profile",
-                vision,
+                vision: isVision,
               }),
               version: "1.0.0",
             };
@@ -361,7 +376,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             modelDateMap.set(c.model.modelId, date);
             modelDateMap.set(c.model.modelArn, date);
           }
-          for (const p of applicationProfiles) {
+          for (const p of appProfiles) {
             const date = p.updatedAt ?? p.createdAt;
             modelDateMap.set(p.modelId, date);
             modelDateMap.set(p.modelArn, date);
@@ -572,28 +587,37 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // Look up the bundled models.dev entry for this model. Used as a fallback
       // for capability flags that profiles.ts may not yet enumerate for newly-added
       // models (temperatureDeprecated, tool_call support).
-      const modelsDevMap = loadModelsDevData();
+      const modelsDevelopmentMap = loadModelsDevelopmentData();
       const normalizedBaseId = normalizeModelId(baseModelId);
-      const chatDevEntry =
-        modelsDevMap.get(baseModelId) ??
-        modelsDevMap.get(normalizedBaseId) ??
+      const chatDevelopmentEntry =
+        modelsDevelopmentMap.get(baseModelId) ??
+        modelsDevelopmentMap.get(normalizedBaseId) ??
         (() => {
           // Full-scan fallback: strip version suffix and match by normalized prefix
-          for (const [key, entry] of modelsDevMap) {
+          for (const [key, entry] of modelsDevelopmentMap) {
             if (normalizeModelId(key) === normalizedBaseId) return entry;
           }
         })();
 
       // temperatureDeprecated: profiles.ts is authoritative; fall back to
       // models.dev `temperature: false` for models not yet enumerated.
-      const effectiveTemperatureDeprecated =
-        modelProfile.temperatureDeprecated || chatDevEntry?.temperature === false;
+      // User can override with bedrock.temperature.override setting:
+      // - null/undefined = use auto-detection (default)
+      // - true = disable temperature on all models (temperatureDeprecated = true)
+      // - false = enable temperature on all models (temperatureDeprecated = false)
+      let isEffectiveTemperatureDeprecated =
+        modelProfile.temperatureDeprecated || chatDevelopmentEntry?.temperature === false;
+
+      if (settings.temperature.override !== undefined) {
+        // User override: true means disable temp (deprecated), false means enable temp (not deprecated)
+        isEffectiveTemperatureDeprecated = settings.temperature.override;
+      }
 
       // tool_call: profiles.ts is authoritative; fall back to models.dev
       // `tool_call: false` to suppress tool configs for unknown models that
       // reject them (avoids ValidationException on new text-only additions).
-      const effectiveToolCallSupported =
-        modelProfile.supportsToolChoice || chatDevEntry?.tool_call !== false;
+      const isEffectiveToolCallSupported =
+        modelProfile.supportsToolChoice || chatDevelopmentEntry?.tool_call !== false;
 
       // Apply per-request overrides from the VS Code model-picker UI.
       // When the user selects a context size, thinking effort, or reasoning
@@ -607,7 +631,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // context1M override: the picker value fully overrides settings.context1M.enabled
       // for this request — so the user can turn 1M *off* for a single request even when
       // the workspace setting has it enabled.
-      const context1MEnabled =
+      const isContext1MEnabled =
         typeof mc?.contextSize === "number"
           ? mc.contextSize >= 1_000_000
           : settings.context1M.enabled;
@@ -628,13 +652,21 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       const effectiveThinkingEffort: ThinkingEffort =
         thinkingEffortOverride ?? settings.thinking.effort;
 
-      // reasoningEffort: profiles.ts is authoritative; also enable for models
-      // discovered only via models.dev (devEntry.reasoning=true) so the picker
-      // and the request path stay in sync.
+      // reasoningEffort: profiles.ts is authoritative. A models.dev entry with
+      // reasoning=true can only ADD support when profiles.ts has no explicit
+      // opinion; it must never override an explicit profiles.ts opt-out (e.g.
+      // gpt-5.x-luna variants, which are CLI-verified to reject the field).
       const isAnthropicBaseModel = baseModelId.toLowerCase().includes("anthropic.");
-      const effectiveSupportsReasoningEffort =
-        modelProfile.supportsReasoningEffort ||
-        (chatDevEntry?.reasoning === true && !isAnthropicBaseModel);
+      const isLunaVariant =
+        baseModelId.includes("gpt-5.4-luna") ||
+        baseModelId.includes("gpt-5.5-luna") ||
+        baseModelId.includes("gpt-5.6-luna");
+      const isEffectiveSupportsReasoningEffort =
+        !isLunaVariant &&
+        (modelProfile.supportsReasoningEffort ||
+          (modelProfile.supportsReasoningEffort &&
+            chatDevelopmentEntry?.reasoning === true &&
+            !isAnthropicBaseModel));
 
       // reasoningEffort override: picker value wins over workspace setting.
       const validReasoningEfforts: readonly ReasoningEffort[] = [
@@ -653,7 +685,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
       if (mc && Object.keys(mc).length > 0) {
         logger.debug("[Bedrock Model Provider] Applying modelConfiguration overrides", {
-          context1MEnabled,
+          context1MEnabled: isContext1MEnabled,
           modelConfiguration: mc,
           reasoningEffort: effectiveReasoningEffort,
           thinkingEffort: effectiveThinkingEffort,
@@ -680,7 +712,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           maxTokensForRequest,
           settings.thinking.enabled,
         );
-      let extendedThinkingEnabled = initialThinkingEnabled;
+      let isExtendedThinkingEnabled = initialThinkingEnabled;
 
       // Check if we can actually use extended thinking with the current conversation history
       // When thinking is enabled, ALL assistant messages must have thinking blocks.
@@ -689,35 +721,35 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // - There are no previous assistant messages (first turn), OR
       // - There is exactly one previous assistant message AND we have a stored thinking block
       // If there are 2+ assistant messages, we can't provide thinking blocks for all of them.
-      if (extendedThinkingEnabled) {
-        const assistantMsgCount = messages.filter(
+      if (isExtendedThinkingEnabled) {
+        const assistantMessageCount = messages.filter(
           (m) => m.role === vscode.LanguageModelChatMessageRole.Assistant,
         ).length;
 
-        if (assistantMsgCount > 1) {
+        if (assistantMessageCount > 1) {
           // Can't inject thinking blocks for multiple previous assistant messages
           // Each assistant message needs its own unique thinking block, but we only have one stored
           logger.warn(
             "[Bedrock Model Provider] Disabling extended thinking - multiple assistant messages in history require individual thinking blocks",
-            { assistantMsgCount },
+            { assistantMsgCount: assistantMessageCount },
           );
-          extendedThinkingEnabled = false;
+          isExtendedThinkingEnabled = false;
           // Clear stale thinking block to prevent it from being misapplied if conversation
           // history later truncates back to a single assistant message (signatures are
           // integrity-bound to specific thinking blocks)
           this.lastThinkingBlock = undefined;
-        } else if (assistantMsgCount === 1 && !this.lastThinkingBlock?.signature) {
+        } else if (assistantMessageCount === 1 && !this.lastThinkingBlock?.signature) {
           // Have one assistant message but no thinking block to inject
           logger.warn(
             "[Bedrock Model Provider] Disabling extended thinking - no stored thinking block available for previous assistant message",
           );
-          extendedThinkingEnabled = false;
+          isExtendedThinkingEnabled = false;
         }
       }
 
       // Convert messages with thinking configuration
       const converted = convertMessages(messages, baseModelId, {
-        extendedThinkingEnabled,
+        extendedThinkingEnabled: isExtendedThinkingEnabled,
         lastThinkingBlock: this.lastThinkingBlock,
         promptCachingEnabled: settings.promptCaching.enabled,
       });
@@ -731,9 +763,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       const toolConfig = convertTools(
         options,
         baseModelId,
-        extendedThinkingEnabled,
+        isExtendedThinkingEnabled,
         settings.promptCaching.enabled,
-        effectiveToolCallSupported,
+        isEffectiveToolCallSupported,
       );
 
       if (options.tools && options.tools.length > 128) {
@@ -741,16 +773,16 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       }
 
       // Determine if thinking effort should be applied (only for Opus 4.5 and Sonnet 4.6)
-      const thinkingEffortEnabled = modelProfile.supportsThinkingEffort;
+      const isThinkingEffortEnabled = modelProfile.supportsThinkingEffort;
 
       // Build beta headers — use the effective context1M flag (may be overridden by
       // the model-picker contextSize selection via modelConfiguration)
       const betaHeaders = this.buildBetaHeaders(
         modelProfile,
         baseModelId,
-        extendedThinkingEnabled,
-        context1MEnabled,
-        thinkingEffortEnabled,
+        isExtendedThinkingEnabled,
+        isContext1MEnabled,
+        isThinkingEffortEnabled,
       );
 
       // Build request input — use effective effort values (model-picker overrides win)
@@ -760,27 +792,30 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         converted,
         options,
         toolConfig,
-        extendedThinkingEnabled,
+        isExtendedThinkingEnabled,
         budgetTokens,
         betaHeaders,
-        thinkingEffortEnabled ? effectiveThinkingEffort : undefined,
-        effectiveTemperatureDeprecated,
+        isThinkingEffortEnabled ? effectiveThinkingEffort : undefined,
+        isEffectiveTemperatureDeprecated,
         modelProfile.requiresAdaptiveThinking,
-        effectiveSupportsReasoningEffort ? effectiveReasoningEffort : undefined,
+        isEffectiveSupportsReasoningEffort ? effectiveReasoningEffort : undefined,
       );
 
       // Log request details
       this.logRequestDetails(requestInput);
 
-      // Validate token count
-      await this.validateTokenCount(model, requestInput, token);
-
-      // Process the stream
-      await this.processResponseStream(
+      // Process the stream, with a generic one-shot retry that strips any
+      // request field the model rejects as "unknown"/unsupported. This
+      // protects against Bedrock exposing new models that don't yet support
+      // a parameter our profiles.ts / models.dev heuristics enabled (e.g. a
+      // model rejecting `reasoning_effort`). On retry we surface a warning to
+      // the user so they can report the gap to the extension maintainers.
+      await this.processResponseStreamWithFallback(
         requestInput,
         trackingProgress,
-        extendedThinkingEnabled,
+        isExtendedThinkingEnabled,
         token,
+        model.id,
       );
     } catch (error) {
       // Check for context window overflow errors and provide better error messages
@@ -841,18 +876,52 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     text: LanguageModelChatMessage | string,
     token: CancellationToken,
   ): Promise<number> {
-    // Fallback estimation function
-    const estimateTokens = (input: LanguageModelChatMessage | string): number => {
-      if (typeof input === "string") {
-        return Math.ceil(input.length / 4);
+    // Model-specific token multipliers for accurate local estimation
+    // These override the default length/4 heuristic for models with known token patterns
+    const getTokenMultiplier = (modelId: string): number => {
+      const normalizedId = modelId.toLowerCase();
+
+      // Sonnet models use approximately 1.3x more tokens due to tokenizer characteristics
+      if (normalizedId.includes("sonnet")) {
+        return 1.3;
       }
-      let totalTokens = 0;
-      for (const part of input.content) {
-        if (part instanceof vscode.LanguageModelTextPart) {
-          totalTokens += Math.ceil(part.value.length / 4);
-        }
+
+      // Haiku models use approximately 1.0x (baseline)
+      if (normalizedId.includes("haiku")) {
+        return 1;
       }
-      return totalTokens;
+
+      // Opus models use approximately 1.1x
+      if (normalizedId.includes("opus")) {
+        return 1.1;
+      }
+
+      // OpenAI gpt-5.x models typically use slightly fewer tokens
+      if (normalizedId.includes("gpt-5")) {
+        return 0.95;
+      }
+
+      // Default fallback for unknown models
+      return 1;
+    };
+
+    // Fallback estimation function with model-aware token multipliers
+    const estimateTokens = (input: LanguageModelChatMessage | string, modelId: string): number => {
+      const multiplier = getTokenMultiplier(modelId);
+      const baseEstimate =
+        typeof input === "string"
+          ? input.length / 4
+          : (() => {
+              let total = 0;
+              for (const part of input.content) {
+                if (part instanceof vscode.LanguageModelTextPart) {
+                  total += part.value.length / 4;
+                }
+              }
+              return total;
+            })();
+
+      return Math.ceil(baseEstimate * multiplier);
     };
 
     try {
@@ -884,38 +953,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       try {
         // For simple string input, use estimation (CountTokens API expects structured messages)
         if (typeof text === "string") {
-          return estimateTokens(text);
+          return estimateTokens(text, baseModelId);
         }
 
-        // Convert the message to Bedrock format
-        const settings = await getBedrockSettings(this.globalState);
-        const converted = convertMessages([text], baseModelId, {
-          extendedThinkingEnabled: false,
-          lastThinkingBlock: undefined,
-          promptCachingEnabled: settings.promptCaching.enabled,
-        });
-
-        // Use the CountTokens API
-        const tokenCount = await this.client.countTokens(
-          model.id,
-          {
-            converse: {
-              messages: converted.messages,
-              ...(converted.system.length > 0 ? { system: converted.system } : {}),
-            },
-          },
-          abortController.signal,
-        );
-
-        // If CountTokens API is available, use its result
-        if (tokenCount !== undefined) {
-          logger.debug(`[Bedrock Model Provider] Token count from API: ${tokenCount}`);
-          return tokenCount;
-        }
-
-        // Fall back to estimation if CountTokens is not available
-        logger.debug("[Bedrock Model Provider] CountTokens not available, using estimation");
-        return estimateTokens(text);
+        // Use the local estimate by default. The CountTokens API adds a network
+        // round trip and may be denied even when Converse is permitted.
+        return estimateTokens(text, baseModelId);
       } finally {
         cancellationListener.dispose();
       }
@@ -926,7 +969,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       } else {
         logger.warn("[Bedrock Model Provider] Token count failed, using estimation", error);
       }
-      return estimateTokens(text);
+      return estimateTokens(text, model.id);
     }
   }
 
@@ -961,9 +1004,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
     requestInput.additionalModelRequestFields = {
       thinking: thinkingField,
-      ...(betaHeaders.length > 0 ? { anthropic_beta: betaHeaders } : {}),
+      ...(betaHeaders.length > 0 && { anthropic_beta: betaHeaders }),
       // Add thinking effort for Claude Opus 4.5 and Sonnet 4.6 (controls token expenditure)
-      ...(thinkingEffort ? { output_config: { effort: thinkingEffort } } : {}),
+      ...(thinkingEffort && { output_config: { effort: thinkingEffort } }),
     };
 
     logger.debug("[Bedrock Model Provider] Extended thinking enabled", {
@@ -996,11 +1039,11 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   ): void {
     const openAiIndex = baseModelId.indexOf("openai.");
     const normalizedBaseModelId = openAiIndex === -1 ? baseModelId : baseModelId.slice(openAiIndex);
-    const supportsMinimalReasoningEffort =
+    const isSupportsMinimalReasoningEffort =
       getModelProfile(normalizedBaseModelId).supportsReasoningEffort &&
       normalizedBaseModelId.startsWith("openai.");
     const resolved =
-      reasoningEffort === "minimal" && !supportsMinimalReasoningEffort ? "low" : reasoningEffort;
+      reasoningEffort === "minimal" && !isSupportsMinimalReasoningEffort ? "low" : reasoningEffort;
     requestInput.additionalModelRequestFields = {
       ...((requestInput.additionalModelRequestFields ?? {}) as Record<string, unknown>),
       reasoning_effort: resolved,
@@ -1080,7 +1123,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   private buildConfigurationSchema(
     modelId: string,
     modelProfile: ReturnType<typeof getModelProfile>,
-    modelsDevMap: ModelsDevMap = new Map(),
+    modelsDevelopmentMap: ModelsDevelopmentMap = new Map(),
   ): LanguageModelConfigurationSchema | undefined {
     // Mutable during construction; returned as LanguageModelConfigurationSchema.
     const properties: Record<string, Record<string, unknown>> = {};
@@ -1089,7 +1132,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     // normalizeModelId strips regional prefixes (us., eu., global., etc.) so we
     // can match against the bare model IDs stored in models.dev.
     const normalizedId = normalizeModelId(modelId);
-    const devEntry = modelsDevMap.get(modelId) ?? modelsDevMap.get(normalizedId);
+    const developmentEntry =
+      modelsDevelopmentMap.get(modelId) ?? modelsDevelopmentMap.get(normalizedId);
 
     // ── Context size picker ────────────────────────────────────────────────
     // Only shown for models where 1M context is an *optional* beta-header opt-in
@@ -1192,8 +1236,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     // if models.dev says `reasoning: true` for a non-Anthropic model that
     // profiles.ts doesn't know about yet, show the picker for it too.
     const isAnthropicModel = modelId.toLowerCase().includes("anthropic.");
-    const devSupportsReasoning = devEntry?.reasoning === true && !isAnthropicModel;
-    if (modelProfile.supportsReasoningEffort || devSupportsReasoning) {
+    const isDevelopmentSupportsReasoning =
+      developmentEntry?.reasoning === true && !isAnthropicModel;
+    if (modelProfile.supportsReasoningEffort || isDevelopmentSupportsReasoning) {
       const isOpenAI = modelId.toLowerCase().includes("openai.");
       const effortLevels = isOpenAI
         ? (["minimal", "low", "medium", "high"] as const)
@@ -1250,32 +1295,32 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
       const manualModelProfile = getModelProfile(baseModelId);
       // Load bundled models.dev data for the manual model.
-      const manualModelsDevMap = loadModelsDevData();
+      const manualModelsDevelopmentMap = loadModelsDevelopmentData();
       const limits = this.resolveModelLimits(
         baseModelId,
         settings.context1M.enabled,
-        manualModelsDevMap,
+        manualModelsDevelopmentMap,
       );
-      const devEntry = manualModelsDevMap.get(baseModelId);
-      const likelyVisionCapable = devEntry
-        ? (devEntry.modalities?.input?.includes("image") ?? false)
+      const developmentEntry = manualModelsDevelopmentMap.get(baseModelId);
+      const isLikelyVisionCapable = developmentEntry
+        ? (developmentEntry.modalities?.input?.includes("image") ?? false)
         : /anthropic\.|nova\.|llama\.|pixtral|gpt-oss/i.test(baseModelId);
 
       return {
         capabilities: {
-          imageInput: likelyVisionCapable,
+          imageInput: isLikelyVisionCapable,
           toolCalling: true,
         },
         configurationSchema: this.buildConfigurationSchema(
           baseModelId,
           manualModelProfile,
-          manualModelsDevMap,
+          manualModelsDevelopmentMap,
         ),
         detail: this.formatDetail(
           baseModelId,
           limits.maxInputTokens,
           limits.maxOutputTokens,
-          likelyVisionCapable,
+          isLikelyVisionCapable,
         ),
         family: "bedrock",
         id: modelId,
@@ -1288,7 +1333,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           modelId: baseModelId,
           providerName: "Bedrock",
           route: "Manual entry",
-          vision: likelyVisionCapable,
+          vision: isLikelyVisionCapable,
         }),
         version: "1.0.0",
       };
@@ -1400,13 +1445,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           model.maxOutputTokens,
         ),
         // CLI-verified: Claude Opus 4.7 rejects requests that include
-        // `temperature`. All other models still accept it.
-        ...(!temperatureDeprecated && {
-          temperature:
-            typeof options.modelOptions?.temperature === "number"
-              ? options.modelOptions?.temperature
-              : 0.7,
-        }),
+        // `temperature`. Sonnet 5 also rejects non-default temperature values.
+        // Only include temperature if the user explicitly set one.
+        ...(!temperatureDeprecated &&
+          typeof options.modelOptions?.temperature === "number" && {
+            temperature: options.modelOptions.temperature,
+          }),
       },
       messages: converted.messages,
       modelId: model.id,
@@ -1473,10 +1517,10 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       0,
       Math.min(baseBudget, maxBudgetFromOutput, maxTokensForRequest - visibleReserve),
     );
-    const extendedThinkingEnabled =
+    const isExtendedThinkingEnabled =
       thinkingEnabled && modelProfile.supportsThinking && budgetTokens >= 1024;
 
-    return { budgetTokens, extendedThinkingEnabled };
+    return { budgetTokens, extendedThinkingEnabled: isExtendedThinkingEnabled };
   }
 
   /**
@@ -1508,7 +1552,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // Claude Opus 4.5 and Sonnet 4.6 effort parameter can be used even without extended thinking
       // This affects all token spend including tool calls
       requestInput.additionalModelRequestFields = {
-        ...(betaHeaders.length > 0 ? { anthropic_beta: betaHeaders } : {}),
+        ...(betaHeaders.length > 0 && { anthropic_beta: betaHeaders }),
         output_config: { effort: thinkingEffort },
       };
 
@@ -1516,6 +1560,18 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         anthropicBeta: betaHeaders.length > 0 ? betaHeaders : undefined,
         modelId,
         thinkingEffort,
+      });
+    } else if (requiresAdaptiveThinking) {
+      // For models with adaptive thinking enabled by default (e.g., Sonnet 5),
+      // explicitly send thinking: {type: "disabled"} if the user hasn't enabled extended thinking
+      requestInput.additionalModelRequestFields = {
+        thinking: { type: "disabled" },
+        ...(betaHeaders.length > 0 && { anthropic_beta: betaHeaders }),
+      };
+
+      logger.debug("[Bedrock Model Provider] Adaptive thinking disabled", {
+        anthropicBeta: betaHeaders.length > 0 ? betaHeaders : undefined,
+        modelId,
       });
     } else if (betaHeaders.length > 0) {
       // Add beta headers even without thinking or effort
@@ -1528,113 +1584,6 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
     if (reasoningEffort) {
       this.applyReasoningEffort(requestInput, modelId, baseModelId, reasoningEffort);
-    }
-  }
-
-  /**
-   * Count tokens for a complete request using the CountTokens API.
-   * Falls back to estimation if the API is unavailable or fails.
-   * @param modelId The model ID to count tokens for
-   * @param input The complete input structure (messages, system, toolConfig)
-   * @param token Cancellation token
-   * @returns The number of input tokens
-   */
-  private async countRequestTokens(
-    modelId: string,
-    input: {
-      messages: Message[];
-      system?: SystemContentBlock[];
-      toolConfig?: ToolConfiguration;
-    },
-    token: CancellationToken,
-  ): Promise<number> {
-    // Fallback estimation function
-    const estimateTokens = (): number => {
-      let total = 0;
-
-      // Estimate messages tokens
-      for (const msg of input.messages) {
-        for (const content of msg.content ?? []) {
-          if ("text" in content && content.text) {
-            total += Math.ceil(content.text.length / 4);
-          }
-        }
-      }
-
-      // Estimate system tokens
-      if (input.system) {
-        for (const sys of input.system) {
-          if ("text" in sys && sys.text) {
-            total += Math.ceil(sys.text.length / 4);
-          }
-        }
-      }
-
-      // Estimate tool tokens
-      if ((input.toolConfig?.tools?.length ?? 0) > 0) {
-        try {
-          const json = JSON.stringify(input.toolConfig);
-          total += Math.ceil(json.length / 4);
-        } catch {
-          // Ignore serialization errors
-        }
-      }
-
-      return total;
-    };
-
-    try {
-      // Create AbortController for cancellation support
-      const abortController = new AbortController();
-      const cancellationListener = token.onCancellationRequested(() => {
-        abortController.abort();
-      });
-
-      try {
-        // Deep copy messages and strip thinking content for CountTokens API
-        // The CountTokens API doesn't support thinking blocks when thinking mode is not enabled,
-        // but our messages may contain thinking blocks from previous responses (injected via lastThinkingBlock)
-        const messagesForCounting = structuredClone(input.messages);
-        stripThinkingContent(messagesForCounting);
-
-        // Build the CountTokens API input
-        const countInput: CountTokensCommandInput["input"] = {
-          converse: {
-            messages: messagesForCounting,
-            ...(input.system && input.system.length > 0 ? { system: input.system } : {}),
-            ...(input.toolConfig ? { toolConfig: input.toolConfig } : {}),
-          },
-        };
-
-        // Use the CountTokens API
-        const tokenCount = await this.client.countTokens(
-          modelId,
-          countInput,
-          abortController.signal,
-        );
-
-        // If CountTokens API is available, use its result
-        if (tokenCount !== undefined) {
-          logger.debug(`[Bedrock Model Provider] Request token count from API: ${tokenCount}`);
-          return tokenCount;
-        }
-
-        // Fall back to estimation if CountTokens is not available
-        logger.debug(
-          "[Bedrock Model Provider] CountTokens not available for request, using estimation",
-        );
-        return estimateTokens();
-      } finally {
-        cancellationListener.dispose();
-      }
-    } catch (error) {
-      // If there's any error (including cancellation), fall back to estimation
-      if (error instanceof Error && error.name === "AbortError") {
-        logger.debug("[Bedrock Model Provider] Request token count cancelled, using estimation");
-      } else {
-        logger.warn("[Bedrock Model Provider] Request token count failed, using estimation", error);
-      }
-      return estimateTokens();
     }
   }
 
@@ -1666,12 +1615,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       }
 
       // Profile not in list, validate with Converse as last resort
-      const profileAccessible = await this.client.testInferenceProfileAccess(
+      const isProfileAccessible = await this.client.testInferenceProfileAccess(
         candidate.modelIdToUse,
         abortSignal,
       );
 
-      if (profileAccessible) {
+      if (isProfileAccessible) {
         return { ...candidate, isAccessible: true };
       }
 
@@ -1687,12 +1636,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     // No inference profile; check base model directly
-    const baseModelAccessible = await this.client.isModelAccessible(
+    const isBaseModelAccessible = await this.client.isModelAccessible(
       candidate.model.modelId,
       abortSignal,
     );
 
-    return { ...candidate, isAccessible: baseModelAccessible };
+    return { ...candidate, isAccessible: isBaseModelAccessible };
   }
 
   /**
@@ -1768,11 +1717,11 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     // No accessible profile found, fall back to base model
-    const baseModelAccessible = await this.client.isModelAccessible(
+    const isBaseModelAccessible = await this.client.isModelAccessible(
       candidate.model.modelId,
       abortSignal,
     );
-    if (baseModelAccessible) {
+    if (isBaseModelAccessible) {
       logger.info(
         `[Bedrock Model Provider] No accessible inference profile found for ${candidate.model.modelId}, using base model`,
       );
@@ -1815,8 +1764,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           !excludedProfileIds.has(profileId) && this.isRegionalProfileForModel(profileId, modelId),
       )
       .toSorted((a, b) => {
-        const aPriority = priorityByPrefix.get(a.split(".")[0]) ?? Number.MAX_SAFE_INTEGER;
-        const bPriority = priorityByPrefix.get(b.split(".")[0]) ?? Number.MAX_SAFE_INTEGER;
+        const aPriority = priorityByPrefix.get(a.split(".", 1)[0]) ?? Number.MAX_SAFE_INTEGER;
+        const bPriority = priorityByPrefix.get(b.split(".", 1)[0]) ?? Number.MAX_SAFE_INTEGER;
         return aPriority - bPriority || a.localeCompare(b);
       })[0];
   }
@@ -1837,9 +1786,9 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     const profile = getModelProfile(modelId);
     // Total context window = input budget + output limit (mirrors VS Code picker rendering)
     const totalContext = maxInput + maxOutput;
-    const ctxK = Math.round(totalContext / 1000);
+    const contextK = Math.round(totalContext / 1000);
     const outK = Math.round(maxOutput / 1000);
-    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M` : `${ctxK}K`;
+    const contextLabel = contextK >= 1000 ? `${(contextK / 1000).toFixed(0)}M` : `${contextK}K`;
 
     let thinkingDescription: string | undefined;
     if (profile.requiresAdaptiveThinking) {
@@ -1849,13 +1798,13 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     const parts = [
-      `${ctxLabel} ctx`,
+      `${contextLabel} ctx`,
       `${outK}K out`,
       ...(thinkingDescription ? [thinkingDescription] : []),
       ...(vision ? ["vision"] : []),
     ];
 
-    return parts.join(" \u00B7 ");
+    return parts.join(" \u{B7} ");
   }
 
   /**
@@ -1865,7 +1814,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
    * users can distinguish between, e.g., `us.anthropic.claude-opus-4-7` vs
    * `global.anthropic.claude-opus-4-7` vs the base foundation model.
    */
-  private formatTooltip(args: {
+  private formatTooltip(arguments_: {
     maxInput: number;
     maxOutput: number;
     modelId: string;
@@ -1873,11 +1822,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     route: string;
     vision: boolean;
   }): string {
-    const profile = getModelProfile(args.modelId);
+    const profile = getModelProfile(arguments_.modelId);
     // Total context window = input budget + output limit (mirrors VS Code picker rendering)
-    const totalContext = args.maxInput + args.maxOutput;
-    const ctxK = Math.round(totalContext / 1000);
-    const ctxLabel = ctxK >= 1000 ? `${(ctxK / 1000).toFixed(0)}M tokens` : `${ctxK}K tokens`;
+    const totalContext = arguments_.maxInput + arguments_.maxOutput;
+    const contextK = Math.round(totalContext / 1000);
+    const contextLabel =
+      contextK >= 1000 ? `${(contextK / 1000).toFixed(0)}M tokens` : `${contextK}K tokens`;
 
     let thinkingLine: string | undefined;
     if (profile.requiresAdaptiveThinking) {
@@ -1889,13 +1839,13 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     }
 
     const lines = [
-      `Amazon Bedrock - ${args.providerName}`,
-      `Route: ${args.route}`,
-      `Model ID: ${args.modelId}`,
-      `Context: ${ctxLabel} | Max output: ${Math.round(args.maxOutput / 1000)}K tokens`,
+      `Amazon Bedrock - ${arguments_.providerName}`,
+      `Route: ${arguments_.route}`,
+      `Model ID: ${arguments_.modelId}`,
+      `Context: ${contextLabel} | Max output: ${Math.round(arguments_.maxOutput / 1000)}K tokens`,
       ...(thinkingLine ? [thinkingLine] : []),
       ...(profile.temperatureDeprecated ? ["Note: temperature parameter is not supported"] : []),
-      ...(args.vision ? ["Vision: image input supported"] : []),
+      ...(arguments_.vision ? ["Vision: image input supported"] : []),
     ];
 
     return lines.join("\n");
@@ -2019,8 +1969,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
    */
   private logConvertedMessages(messages: Message[]): void {
     logger.debug("[Bedrock Model Provider] Converted to Bedrock messages:", messages.length);
-    for (const [idx, msg] of messages.entries()) {
-      const contentTypes = msg.content?.map((c) => {
+    for (const [index, message] of messages.entries()) {
+      const contentTypes = message.content?.map((c) => {
         if ("text" in c) return "text";
         if ("image" in c) return "image";
         if ("toolUse" in c) return "toolUse";
@@ -2030,7 +1980,10 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         if ("cachePoint" in c) return "cachePoint";
         return "unknown";
       });
-      logger.debug(`[Bedrock Model Provider] Bedrock message ${idx} (${msg.role}):`, contentTypes);
+      logger.debug(
+        `[Bedrock Model Provider] Bedrock message ${index} (${message.role}):`,
+        contentTypes,
+      );
     }
   }
 
@@ -2043,8 +1996,8 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
 
     // Log full incoming VSCode messages at trace level for reproduction
     logger.trace("[Bedrock Model Provider] Full VSCode messages for reproduction:", {
-      messages: messages.map((msg) => ({
-        content: msg.content.map((part) => {
+      messages: messages.map((message) => ({
+        content: message.content.map((part) => {
           if (part instanceof vscode.LanguageModelTextPart) {
             return { type: "text", value: part.value };
           }
@@ -2055,7 +2008,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
             return { callId: part.callId, content: part.content, type: "toolResult" };
           }
           if (typeof part === "object" && part != null && "mimeType" in part && "data" in part) {
-            const dataPart = part;
+            const dataPart = part as { data: Uint8Array; mimeType: string };
             return {
               dataLength: dataPart.data.length,
               mimeType: dataPart.mimeType,
@@ -2064,12 +2017,12 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
           }
           return { type: "unknown" };
         }),
-        role: msg.role,
+        role: message.role,
       })),
     });
 
-    for (const [idx, msg] of messages.entries()) {
-      const partTypes = msg.content.map((p) => {
+    for (const [index, message] of messages.entries()) {
+      const partTypes = message.content.map((p) => {
         if (p instanceof vscode.LanguageModelTextPart) return "text";
         if (p instanceof vscode.LanguageModelToolCallPart) {
           return `toolCall(${p.name})`;
@@ -2091,25 +2044,27 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
         }
         return "unknown";
       });
-      logger.debug(`[Bedrock Model Provider] Message ${idx} (${msg.role}):`, partTypes);
+      logger.debug(`[Bedrock Model Provider] Message ${index} (${message.role}):`, partTypes);
       // Log tool result details
-      for (const part of msg.content) {
-        if (part instanceof vscode.LanguageModelToolResultPart) {
-          let contentPreview = "[Unable to preview]";
-          try {
-            const contentStr =
-              typeof part.content === "string" ? part.content : JSON.stringify(part.content);
-            contentPreview = contentStr.slice(0, 100);
-          } catch {
-            // Keep default
-          }
-          logger.debug(`[Bedrock Model Provider]   Tool Result:`, {
-            callId: part.callId,
-            contentPreview,
-            contentType: typeof part.content,
-            isError: "isError" in part ? part.isError : false,
-          });
+      for (const part of message.content) {
+        if (!(part instanceof vscode.LanguageModelToolResultPart)) {
+          continue;
         }
+
+        let contentPreview = "[Unable to preview]";
+        try {
+          const contentString =
+            typeof part.content === "string" ? part.content : JSON.stringify(part.content);
+          contentPreview = contentString.slice(0, 100);
+        } catch {
+          // Keep default
+        }
+        logger.debug(`[Bedrock Model Provider]   Tool Result:`, {
+          callId: part.callId,
+          contentPreview,
+          contentType: typeof part.content,
+          isError: "isError" in part ? part.isError : false,
+        });
       }
     }
   }
@@ -2214,6 +2169,67 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   }
 
   /**
+   * Wraps {@link processResponseStream} with a single generic retry: if Bedrock
+   * rejects the request because of an unsupported/unknown parameter (typically
+   * a field we opted the model into via profiles.ts or a models.dev heuristic,
+   * but which this particular model build doesn't actually support), we strip
+   * that field from the request and retry exactly once. A warning is surfaced
+   * to the user (via a text part) so they know the extension auto-recovered
+   * and can report the gap upstream.
+   *
+   * This guards against Bedrock adding new models that don't match our
+   * hardcoded capability assumptions, without requiring a code change for
+   * every such mismatch.
+   */
+  private async processResponseStreamWithFallback(
+    requestInput: ConverseStreamCommandInput,
+    trackingProgress: Progress<LanguageModelResponsePart2>,
+    extendedThinkingEnabled: boolean,
+    token: CancellationToken,
+    modelId: string,
+  ): Promise<void> {
+    try {
+      await this.processResponseStream(
+        requestInput,
+        trackingProgress,
+        extendedThinkingEnabled,
+        token,
+      );
+    } catch (error) {
+      const unsupportedParameterName = getUnsupportedParameterName(error);
+      if (!unsupportedParameterName) {
+        throw error;
+      }
+
+      const wasRemoved = didRemoveUnsupportedParameter(requestInput, unsupportedParameterName);
+      if (!wasRemoved) {
+        // We recognized the error shape but couldn't locate/remove the field
+        // (e.g. it lives somewhere we don't know how to strip) -- don't retry
+        // blindly, just surface the original error.
+        throw error;
+      }
+
+      logger.warn("[Bedrock Model Provider] Retrying after stripping unsupported parameter", {
+        modelId,
+        parameter: unsupportedParameterName,
+      });
+
+      const warningMessage =
+        ` **Bedrock Copilot Chat**: model \`${modelId}\` rejected the \`${unsupportedParameterName}\` ` +
+        "parameter. Retried without it. Please report this to the extension developers " +
+        "(github.com/vtkn/amazon-bedrock-copilot-chat/issues) so support can be fixed.\n\n";
+      trackingProgress.report(new vscode.LanguageModelTextPart(warningMessage));
+
+      await this.processResponseStream(
+        requestInput,
+        trackingProgress,
+        extendedThinkingEnabled,
+        token,
+      );
+    }
+  }
+
+  /**
    * Resolve token limits for a model, preferring live data from models.dev over
    * the hardcoded `getModelTokenLimits` fallback.
    *
@@ -2231,7 +2247,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
   private resolveModelLimits(
     modelId: string,
     context1MEnabled: boolean,
-    modelsDevMap: ModelsDevMap,
+    modelsDevelopmentMap: ModelsDevelopmentMap,
   ): { maxInputTokens: number; maxOutputTokens: number } {
     // normalizeModelId strips regional prefixes (us., eu., global., etc.) so we
     // can match against the bare model IDs stored in models.dev.
@@ -2239,77 +2255,43 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     // so a direct + normalized lookup may still miss entries stored under a
     // different prefix variant. Fall back to a full-map scan by normalized ID.
     const normalizedId = normalizeModelId(modelId);
-    let devEntry = modelsDevMap.get(modelId) ?? modelsDevMap.get(normalizedId);
-    if (!devEntry) {
-      for (const [key, entry] of modelsDevMap) {
+    let developmentEntry =
+      modelsDevelopmentMap.get(modelId) ?? modelsDevelopmentMap.get(normalizedId);
+    if (!developmentEntry) {
+      for (const [key, entry] of modelsDevelopmentMap) {
         if (normalizeModelId(key) === normalizedId) {
-          devEntry = entry;
+          developmentEntry = entry;
           break;
         }
       }
     }
 
-    if (devEntry) {
-      const devOutput = devEntry.limit.output;
-      const devContext = devEntry.limit.context;
+    if (developmentEntry) {
+      const developmentOutput = developmentEntry.limit.output;
+      const developmentContext = developmentEntry.limit.context;
 
       // VS Code renders the context window size in the model picker as
       // `maxInputTokens + maxOutputTokens`, so maxInputTokens must be the input
       // budget (context - output), not the raw context window.
       //
       // For models with optional 1M context (requires beta header opt-in), respect the setting.
-      if (devContext >= 1_000_000 && requires1MContextBetaHeader(modelId)) {
-        const effectiveContext = context1MEnabled ? devContext : 200_000;
+      if (developmentContext >= 1_000_000 && requires1MContextBetaHeader(modelId)) {
+        const effectiveContext = context1MEnabled ? developmentContext : 200_000;
         return {
-          maxInputTokens: effectiveContext - devOutput,
-          maxOutputTokens: devOutput,
+          maxInputTokens: effectiveContext - developmentOutput,
+          maxOutputTokens: developmentOutput,
         };
       }
 
       // For all other models (including always-1M like Opus 4.7/4.8), use live limits directly.
       return {
-        maxInputTokens: devContext - devOutput,
-        maxOutputTokens: devOutput,
+        maxInputTokens: developmentContext - developmentOutput,
+        maxOutputTokens: developmentOutput,
       };
     }
 
     // Fall back to hardcoded profiles for models not yet in models.dev
     return getModelTokenLimits(modelId, context1MEnabled);
-  }
-
-  /**
-   * Validate token count against model limits
-   */
-  private async validateTokenCount(
-    model: LanguageModelChatInformation,
-    requestInput: ConverseStreamCommandInput,
-    token: CancellationToken,
-  ): Promise<void> {
-    const inputTokenCount = await this.countRequestTokens(
-      model.id,
-      {
-        messages: requestInput.messages!,
-        system: requestInput.system,
-        toolConfig: requestInput.toolConfig,
-      },
-      token,
-    );
-
-    const tokenLimit = Math.max(1, model.maxInputTokens);
-    if (inputTokenCount > tokenLimit) {
-      logger.error("[Bedrock Model Provider] Message exceeds token limit", {
-        inputTokenCount,
-        tokenLimit,
-      });
-      throw new Error(
-        `Message exceeds token limit. Input: ${inputTokenCount} tokens, Limit: ${tokenLimit} tokens.`,
-      );
-    }
-
-    logger.debug("[Bedrock Model Provider] Token count validation passed", {
-      inputTokenCount,
-      tokenLimit,
-    });
   }
 }
 
@@ -2334,5 +2316,98 @@ function isContextWindowOverflowError(error: unknown): boolean {
   }
 
   const errorMessage = error instanceof Error ? error.message : inspect(error);
-  return CONTEXT_WINDOW_OVERFLOW_MESSAGES.some((msg) => errorMessage.includes(msg));
+  return CONTEXT_WINDOW_OVERFLOW_MESSAGES.some((message) => errorMessage.includes(message));
 }
+
+/**
+ * Regexes matching known "unsupported/unknown parameter" error shapes from
+ * Bedrock-fronted providers (OpenAI-compatible passthrough errors, and
+ * Bedrock's own ValidationException wording). Each must capture the offending
+ * parameter name in group 1.
+ */
+const UNSUPPORTED_PARAMETER_PATTERNS = [
+  // OpenAI-compatible passthrough error, e.g.:
+  // {"error":{"code":"unknown_parameter","message":"Unknown parameter: 'reasoning_effort'.","param":"reasoning_effort", ...}}
+  /"param"\s*:\s*"([\w.]+)"[^}]*"unknown_parameter"/,
+  /"unknown_parameter"[^}]*"param"\s*:\s*"([\w.]+)"/,
+  /Unknown parameter:\s*'([\w.]+)'/i,
+  // Bedrock ValidationException wording for unrecognized additionalModelRequestFields keys
+  /Unrecognized (?:request )?(?:field|parameter|argument)[:\s]+['"]?([\w.]+)['"]?/i,
+  /extraneous key \[([\w.]+)\] is not permitted/i,
+];
+
+/**
+ * Remove a top-level or `additionalModelRequestFields`-nested parameter from
+ * the request input, mutating it in place. Returns true if the field was
+ * found and removed, false otherwise (caller should not retry in that case).
+ */
+function didRemoveUnsupportedParameter(
+  requestInput: ConverseStreamCommandInput,
+  parameterName: string,
+): boolean {
+  const additionalFields = requestInput.additionalModelRequestFields as
+    | Record<string, unknown>
+    | undefined;
+
+  if (additionalFields && Object.hasOwn(additionalFields, parameterName)) {
+    delete additionalFields[parameterName];
+    return true;
+  }
+
+  // Also handle dotted paths like "output_config.effort"
+  if (parameterName.includes(".") && additionalFields) {
+    const [rootKey, ...pathRest] = parameterName.split(".");
+    const root = additionalFields[rootKey];
+    if (pathRest.length > 0 && root && typeof root === "object") {
+      let cursor: Record<string, unknown> = root as Record<string, unknown>;
+      for (let index = 0; index < pathRest.length - 1; index++) {
+        const next = cursor[pathRest[index]];
+        if (!next || typeof next !== "object") {
+          return false;
+        }
+        cursor = next as Record<string, unknown>;
+      }
+      const leafKey = pathRest.at(-1)!;
+      if (Object.hasOwn(cursor, leafKey)) {
+        delete cursor[leafKey];
+        return true;
+      }
+    }
+  }
+
+  const requestRecord = requestInput as unknown as Record<string, unknown>;
+  if (Object.hasOwn(requestRecord, parameterName)) {
+    delete requestRecord[parameterName];
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Attempt to extract the name of an unsupported/unknown parameter from a
+ * Bedrock/Converse API error. Returns undefined if the error doesn't match
+ * any known "unknown parameter" shape.
+ */
+function getUnsupportedParameterName(error: unknown): string | undefined {
+  if (!error) {
+    return undefined;
+  }
+
+  const errorMessage = error instanceof Error ? error.message : inspect(error);
+  for (const pattern of UNSUPPORTED_PARAMETER_PATTERNS) {
+    const match = pattern.exec(errorMessage);
+    if (match?.[1]) {
+      return match[1];
+    }
+  }
+  return undefined;
+}
+
+/* eslint-enable unicorn/consistent-boolean-name -- end intentional file-level exception */
+/* eslint-enable unicorn/consistent-class-member-order -- end intentional file-level exception */
+/* eslint-enable unicorn/consistent-function-scoping -- end intentional file-level exception */
+/* eslint-enable unicorn/no-break-in-nested-loop -- end intentional file-level exception */
+/* eslint-enable unicorn/prefer-includes-over-repeated-comparisons -- end intentional file-level exception */
+/* eslint-enable unicorn/prefer-simple-condition-first -- end intentional file-level exception */
+/* eslint-enable unicorn/prefer-ternary -- end intentional file-level exception */

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,21 +8,21 @@
 
 import { ModelModality } from "@aws-sdk/client-bedrock";
 import type {
-  ConverseStreamCommandInput,
-  Message,
-  SystemContentBlock,
-  ToolConfiguration,
+    ConverseStreamCommandInput,
+    Message,
+    SystemContentBlock,
+    ToolConfiguration,
 } from "@aws-sdk/client-bedrock-runtime";
 import { inspect, MIMEType } from "node:util";
 import type {
-  CancellationToken,
-  LanguageModelChatInformation,
-  LanguageModelChatMessage,
-  LanguageModelChatProvider,
-  LanguageModelConfigurationSchema,
-  LanguageModelResponsePart,
-  LanguageModelResponsePart2,
-  Progress,
+    CancellationToken,
+    LanguageModelChatInformation,
+    LanguageModelChatMessage,
+    LanguageModelChatProvider,
+    LanguageModelConfigurationSchema,
+    LanguageModelResponsePart,
+    LanguageModelResponsePart2,
+    Progress,
 } from "vscode";
 import * as vscode from "vscode";
 
@@ -33,18 +33,18 @@ import { convertTools } from "./converters/tools";
 import { logger } from "./logger";
 import { loadModelsDevData as loadModelsDevelopmentData } from "./models-dev";
 import {
-  getModelProfile,
-  getModelTokenLimits,
-  normalizeModelId,
-  requires1MContextBetaHeader,
+    getModelProfile,
+    getModelTokenLimits,
+    normalizeModelId,
+    requires1MContextBetaHeader,
 } from "./profiles";
 import { getBedrockSettings, type ReasoningEffort, type ThinkingEffort } from "./settings";
 import { StreamProcessor, type ThinkingBlock } from "./stream-processor";
 import type {
-  AuthConfig,
-  AuthMethod,
-  BedrockModelSummary,
-  ModelsDevMap as ModelsDevelopmentMap,
+    AuthConfig,
+    AuthMethod,
+    BedrockModelSummary,
+    ModelsDevMap as ModelsDevelopmentMap,
 } from "./types";
 import { validateBedrockMessages } from "./validation";
 
@@ -664,9 +664,7 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       const isEffectiveSupportsReasoningEffort =
         !isLunaVariant &&
         (modelProfile.supportsReasoningEffort ||
-          (modelProfile.supportsReasoningEffort &&
-            chatDevelopmentEntry?.reasoning === true &&
-            !isAnthropicBaseModel));
+          (chatDevelopmentEntry?.reasoning === true && !isAnthropicBaseModel));
 
       // reasoningEffort override: picker value wins over workspace setting.
       const validReasoningEfforts: readonly ReasoningEffort[] = [
@@ -2337,6 +2335,34 @@ const UNSUPPORTED_PARAMETER_PATTERNS = [
 ];
 
 /**
+ * Delete a dotted path (e.g. "output_config.effort") from a nested record,
+ * mutating it in place. Returns true if the leaf key was found and removed.
+ */
+function didDeleteDottedPath(root: Record<string, unknown>, dottedPath: string): boolean {
+  const [rootKey, ...pathRest] = dottedPath.split(".");
+  const rootValue = root[rootKey];
+  if (pathRest.length === 0 || !rootValue || typeof rootValue !== "object") {
+    return false;
+  }
+
+  let cursor: Record<string, unknown> = rootValue as Record<string, unknown>;
+  for (let index = 0; index < pathRest.length - 1; index++) {
+    const next = cursor[pathRest[index]];
+    if (!next || typeof next !== "object") {
+      return false;
+    }
+    cursor = next as Record<string, unknown>;
+  }
+
+  const leafKey = pathRest.at(-1)!;
+  if (!Object.hasOwn(cursor, leafKey)) {
+    return false;
+  }
+  delete cursor[leafKey];
+  return true;
+}
+
+/**
  * Remove a top-level or `additionalModelRequestFields`-nested parameter from
  * the request input, mutating it in place. Returns true if the field was
  * found and removed, false otherwise (caller should not retry in that case).
@@ -2345,6 +2371,19 @@ function didRemoveUnsupportedParameter(
   requestInput: ConverseStreamCommandInput,
   parameterName: string,
 ): boolean {
+  // temperature/topP/stopSequences live under inferenceConfig, not at the
+  // request root or in additionalModelRequestFields. Support both the bare
+  // key (e.g. "temperature") and the dotted form some providers report
+  // (e.g. "inferenceConfig.temperature").
+  const inferenceConfig = requestInput.inferenceConfig as Record<string, unknown> | undefined;
+  const inferenceConfigKey = parameterName.startsWith("inferenceConfig.")
+    ? parameterName.slice("inferenceConfig.".length)
+    : parameterName;
+  if (inferenceConfig && Object.hasOwn(inferenceConfig, inferenceConfigKey)) {
+    delete inferenceConfig[inferenceConfigKey];
+    return true;
+  }
+
   const additionalFields = requestInput.additionalModelRequestFields as
     | Record<string, unknown>
     | undefined;
@@ -2355,24 +2394,12 @@ function didRemoveUnsupportedParameter(
   }
 
   // Also handle dotted paths like "output_config.effort"
-  if (parameterName.includes(".") && additionalFields) {
-    const [rootKey, ...pathRest] = parameterName.split(".");
-    const root = additionalFields[rootKey];
-    if (pathRest.length > 0 && root && typeof root === "object") {
-      let cursor: Record<string, unknown> = root as Record<string, unknown>;
-      for (let index = 0; index < pathRest.length - 1; index++) {
-        const next = cursor[pathRest[index]];
-        if (!next || typeof next !== "object") {
-          return false;
-        }
-        cursor = next as Record<string, unknown>;
-      }
-      const leafKey = pathRest.at(-1)!;
-      if (Object.hasOwn(cursor, leafKey)) {
-        delete cursor[leafKey];
-        return true;
-      }
-    }
+  if (
+    parameterName.includes(".") &&
+    additionalFields &&
+    didDeleteDottedPath(additionalFields, parameterName)
+  ) {
+    return true;
   }
 
   const requestRecord = requestInput as unknown as Record<string, unknown>;

--- a/src/provider.ts
+++ b/src/provider.ts
@@ -8,21 +8,21 @@
 
 import { ModelModality } from "@aws-sdk/client-bedrock";
 import type {
-    ConverseStreamCommandInput,
-    Message,
-    SystemContentBlock,
-    ToolConfiguration,
+  ConverseStreamCommandInput,
+  Message,
+  SystemContentBlock,
+  ToolConfiguration,
 } from "@aws-sdk/client-bedrock-runtime";
 import { inspect, MIMEType } from "node:util";
 import type {
-    CancellationToken,
-    LanguageModelChatInformation,
-    LanguageModelChatMessage,
-    LanguageModelChatProvider,
-    LanguageModelConfigurationSchema,
-    LanguageModelResponsePart,
-    LanguageModelResponsePart2,
-    Progress,
+  CancellationToken,
+  LanguageModelChatInformation,
+  LanguageModelChatMessage,
+  LanguageModelChatProvider,
+  LanguageModelConfigurationSchema,
+  LanguageModelResponsePart,
+  LanguageModelResponsePart2,
+  Progress,
 } from "vscode";
 import * as vscode from "vscode";
 
@@ -33,18 +33,18 @@ import { convertTools } from "./converters/tools";
 import { logger } from "./logger";
 import { loadModelsDevData as loadModelsDevelopmentData } from "./models-dev";
 import {
-    getModelProfile,
-    getModelTokenLimits,
-    normalizeModelId,
-    requires1MContextBetaHeader,
+  getModelProfile,
+  getModelTokenLimits,
+  normalizeModelId,
+  requires1MContextBetaHeader,
 } from "./profiles";
 import { getBedrockSettings, type ReasoningEffort, type ThinkingEffort } from "./settings";
 import { StreamProcessor, type ThinkingBlock } from "./stream-processor";
 import type {
-    AuthConfig,
-    AuthMethod,
-    BedrockModelSummary,
-    ModelsDevMap as ModelsDevelopmentMap,
+  AuthConfig,
+  AuthMethod,
+  BedrockModelSummary,
+  ModelsDevMap as ModelsDevelopmentMap,
 } from "./types";
 import { validateBedrockMessages } from "./validation";
 
@@ -655,14 +655,11 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       // reasoningEffort: profiles.ts is authoritative. A models.dev entry with
       // reasoning=true can only ADD support when profiles.ts has no explicit
       // opinion; it must never override an explicit profiles.ts opt-out (e.g.
-      // gpt-5.x-luna variants, which are CLI-verified to reject the field).
+      // gpt-5.x named variants -- Luna/Sol/Terra -- which are CLI-verified to
+      // reject the field).
       const isAnthropicBaseModel = baseModelId.toLowerCase().includes("anthropic.");
-      const isLunaVariant =
-        baseModelId.includes("gpt-5.4-luna") ||
-        baseModelId.includes("gpt-5.5-luna") ||
-        baseModelId.includes("gpt-5.6-luna");
       const isEffectiveSupportsReasoningEffort =
-        !isLunaVariant &&
+        !isNamedGpt5Variant(baseModelId) &&
         (modelProfile.supportsReasoningEffort ||
           (chatDevelopmentEntry?.reasoning === true && !isAnthropicBaseModel));
 
@@ -903,23 +900,41 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
       return 1;
     };
 
+    // Estimate the character length of a single message content part.
+    // Text parts count directly; tool calls/results serialize their payload
+    // so large tool inputs/outputs aren't undercounted as zero tokens.
+    const estimatePartCharLength = (part: unknown): number => {
+      if (part instanceof vscode.LanguageModelTextPart) {
+        return part.value.length;
+      }
+      if (part instanceof vscode.LanguageModelToolCallPart) {
+        try {
+          return JSON.stringify(part.input).length;
+        } catch {
+          return 0;
+        }
+      }
+      if (part instanceof vscode.LanguageModelToolResultPart) {
+        return part.content.reduce(
+          (sum: number, inner: unknown) => sum + estimatePartCharLength(inner),
+          0,
+        );
+      }
+      return 0;
+    };
+
     // Fallback estimation function with model-aware token multipliers
     const estimateTokens = (input: LanguageModelChatMessage | string, modelId: string): number => {
       const multiplier = getTokenMultiplier(modelId);
-      const baseEstimate =
+      const charLength =
         typeof input === "string"
-          ? input.length / 4
-          : (() => {
-              let total = 0;
-              for (const part of input.content) {
-                if (part instanceof vscode.LanguageModelTextPart) {
-                  total += part.value.length / 4;
-                }
-              }
-              return total;
-            })();
+          ? input.length
+          : input.content.reduce(
+              (sum: number, part: unknown) => sum + estimatePartCharLength(part),
+              0,
+            );
 
-      return Math.ceil(baseEstimate * multiplier);
+      return Math.ceil((charLength / 4) * multiplier);
     };
 
     try {
@@ -1233,10 +1248,16 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     // Use profiles.ts flag as primary signal. Supplement with models.dev:
     // if models.dev says `reasoning: true` for a non-Anthropic model that
     // profiles.ts doesn't know about yet, show the picker for it too.
+    // gpt-5.x named variants (Luna/Sol/Terra) are excluded even if models.dev
+    // reports `reasoning: true` -- they're CLI-verified to reject the field,
+    // so the picker would offer a control with no effect (see isNamedGpt5Variant).
     const isAnthropicModel = modelId.toLowerCase().includes("anthropic.");
     const isDevelopmentSupportsReasoning =
       developmentEntry?.reasoning === true && !isAnthropicModel;
-    if (modelProfile.supportsReasoningEffort || isDevelopmentSupportsReasoning) {
+    if (
+      !isNamedGpt5Variant(modelId) &&
+      (modelProfile.supportsReasoningEffort || isDevelopmentSupportsReasoning)
+    ) {
       const isOpenAI = modelId.toLowerCase().includes("openai.");
       const effortLevels = isOpenAI
         ? (["minimal", "low", "medium", "high"] as const)
@@ -2291,6 +2312,21 @@ export class BedrockChatModelProvider implements vscode.Disposable, LanguageMode
     // Fall back to hardcoded profiles for models not yet in models.dev
     return getModelTokenLimits(modelId, context1MEnabled);
   }
+}
+
+/**
+ * GPT-5.x named variants (Luna, Sol, Terra) are CLI-verified via
+ * `aws bedrock-runtime converse` (2026-08-22) to reject the `reasoning_effort`
+ * field with an "unknown_parameter" error, even though models.dev reports
+ * `reasoning: true` for all three -- that flag is misleading for Bedrock's
+ * actual behavior on these specific model IDs. Shared by both the
+ * configuration schema (picker visibility) and request building (actual
+ * field inclusion) so the two can never drift out of sync.
+ */
+function isNamedGpt5Variant(baseModelId: string): boolean {
+  return (
+    baseModelId.includes("-luna") || baseModelId.includes("-sol") || baseModelId.includes("-terra")
+  );
 }
 
 /**

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,9 @@ export interface BedrockSettings {
   };
   reasoningEffort: ReasoningEffort | undefined;
   region: string;
+  temperature: {
+    override: boolean | undefined;
+  };
   thinking: {
     budgetTokens: number;
     effort: ThinkingEffort;
@@ -105,13 +108,13 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
   }
 
   // Read 1M context settings with defaults (enabled by default)
-  const context1MEnabled = config.get<boolean>("context1M.enabled") ?? true;
+  const isContext1MEnabled = config.get<boolean>("context1M.enabled") ?? true;
 
   // Read prompt caching settings with defaults (enabled by default)
-  const promptCachingEnabled = config.get<boolean>("promptCaching.enabled") ?? true;
+  const isPromptCachingEnabled = config.get<boolean>("promptCaching.enabled") ?? true;
 
   // Read inference profiles settings with defaults (prefer global by default for backward compatibility)
-  const preferRegionalInferenceProfiles =
+  const isPreferRegionalInferenceProfiles =
     config.get<boolean>("inferenceProfiles.preferRegional") ?? false;
 
   // Read thinking settings with defaults
@@ -120,7 +123,8 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
   const copilotThinkingEnabled = copilotConfig.get<boolean>("thinking.enabled");
   const copilotThinkingMaxTokens = copilotConfig.get<number>("thinking.maxTokens");
 
-  const thinkingEnabled = copilotThinkingEnabled ?? config.get<boolean>("thinking.enabled") ?? true;
+  const isThinkingEnabled =
+    copilotThinkingEnabled ?? config.get<boolean>("thinking.enabled") ?? true;
   const thinkingBudgetTokens =
     copilotThinkingMaxTokens ?? config.get<number>("thinking.budgetTokens") ?? 10_000;
 
@@ -145,22 +149,25 @@ export async function getBedrockSettings(globalState: vscode.Memento): Promise<B
 
   return {
     context1M: {
-      enabled: context1MEnabled,
+      enabled: isContext1MEnabled,
     },
     inferenceProfiles: {
-      preferRegional: preferRegionalInferenceProfiles,
+      preferRegional: isPreferRegionalInferenceProfiles,
     },
     preferredModel,
     profile,
     promptCaching: {
-      enabled: promptCachingEnabled,
+      enabled: isPromptCachingEnabled,
     },
     reasoningEffort,
     region,
+    temperature: {
+      override: config.get<boolean | null>("temperature.override") ?? undefined,
+    },
     thinking: {
       budgetTokens: Math.max(1024, thinkingBudgetTokens), // Ensure minimum 1024
       effort: thinkingEffort,
-      enabled: thinkingEnabled,
+      enabled: isThinkingEnabled,
     },
   };
 }

--- a/src/test/provider.test.ts
+++ b/src/test/provider.test.ts
@@ -7,7 +7,7 @@ import { convertTools } from "../converters/tools";
 import { logger } from "../logger";
 import { getModelProfile, normalizeModelId } from "../profiles";
 import { BedrockChatModelProvider } from "../provider";
-import type { BedrockModelSummary, ModelsDevMap } from "../types";
+import type { BedrockModelSummary, ModelsDevMap as ModelsDevelopmentMap } from "../types";
 
 interface ProviderInternals {
   applyReasoningEffort: (
@@ -26,10 +26,10 @@ interface ProviderInternals {
   buildConfigurationSchema: (
     modelId: string,
     modelProfile: ReturnType<typeof getModelProfile>,
-    modelsDevMap?: ModelsDevMap,
+    modelsDevelopmentMap?: ModelsDevelopmentMap,
   ) => undefined | { properties?: Record<string, Record<string, unknown>> };
   formatDetail: (modelId: string, maxInput: number, maxOutput: number, vision: boolean) => string;
-  formatTooltip: (args: {
+  formatTooltip: (arguments_: {
     maxInput: number;
     maxOutput: number;
     modelId: string;
@@ -40,7 +40,7 @@ interface ProviderInternals {
   resolveModelLimits: (
     modelId: string,
     context1MEnabled: boolean,
-    modelsDevMap: ModelsDevMap,
+    modelsDevelopmentMap: ModelsDevelopmentMap,
   ) => { maxInputTokens: number; maxOutputTokens: number };
 }
 
@@ -135,23 +135,23 @@ const callBuildRequestInput = (
   ) as ConverseStreamCommandInput;
 };
 
-const callBuildConfigurationSchema = (modelId: string, modelsDevMap: ModelsDevMap = new Map()) => {
+const callBuildConfigSchema = (modelId: string, modelsDevelopmentMap: ModelsDevelopmentMap = new Map()) => {
   const provider = providerInternals(
     new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
   );
-  return provider.buildConfigurationSchema(modelId, getModelProfile(modelId), modelsDevMap);
+  return provider.buildConfigurationSchema(modelId, getModelProfile(modelId), modelsDevelopmentMap);
 };
 
 const callResolveModelLimits = (
   modelId: string,
   context1MEnabled: boolean,
-  modelsDevMap: ModelsDevMap,
+  modelsDevelopmentMap: ModelsDevelopmentMap,
 ) =>
   providerInternals(
     new BedrockChatModelProvider(mockSecretStorage, mockGlobalState),
-  ).resolveModelLimits(modelId, context1MEnabled, modelsDevMap);
+  ).resolveModelLimits(modelId, context1MEnabled, modelsDevelopmentMap);
 
-const makeDevMapEntry = (modelId: string, context: number, output: number): ModelsDevMap =>
+const makeDevelopmentMapEntry = (modelId: string, context: number, output: number): ModelsDevelopmentMap =>
   new Map([[modelId, { limit: { context, output } }]]);
 
 suite("Amazon Bedrock Chat Provider Extension", () => {
@@ -184,6 +184,46 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       );
       assert.equal(typeof est, "number");
       assert.ok(est > 0);
+    });
+
+    test("provideTokenCount applies the Sonnet local estimation multiplier", async () => {
+      const provider = new BedrockChatModelProvider(mockSecretStorage, mockGlobalState);
+
+      const est = await provider.provideTokenCount(
+        {
+          capabilities: {},
+          family: "bedrock",
+          id: "global.anthropic.claude-sonnet-5-20251001-v1:0",
+          maxInputTokens: 1_000_000,
+          maxOutputTokens: 64_000,
+          name: "Claude Sonnet",
+          version: "1.0.0",
+        },
+        "a".repeat(100),
+        new vscode.CancellationTokenSource().token,
+      );
+
+      assert.equal(est, 33);
+    });
+
+    test("provideTokenCount keeps the baseline estimate for Haiku", async () => {
+      const provider = new BedrockChatModelProvider(mockSecretStorage, mockGlobalState);
+
+      const est = await provider.provideTokenCount(
+        {
+          capabilities: {},
+          family: "bedrock",
+          id: "global.anthropic.claude-haiku-4-5-20251001-v1:0",
+          maxInputTokens: 200_000,
+          maxOutputTokens: 64_000,
+          name: "Claude Haiku",
+          version: "1.0.0",
+        },
+        "a".repeat(100),
+        new vscode.CancellationTokenSource().token,
+      );
+
+      assert.equal(est, 25);
     });
 
     test("does not add legacy opt-in beta headers for Opus 4.7", () => {
@@ -425,6 +465,31 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
       assert.equal(resultContent.text, "Search results: Found 5 items");
     });
 
+    test("serializes structured tool results as JSON text", () => {
+      const toolResult = new vscode.LanguageModelToolResultPart("call1", [
+        { result: "ok", values: [1, 2, 3] },
+      ]);
+      const messages: vscode.LanguageModelChatMessage[] = [
+        {
+          content: [new vscode.LanguageModelToolCallPart("call1", "search", { q: "cats" })],
+          name: undefined,
+          role: vscode.LanguageModelChatMessageRole.Assistant,
+        },
+        {
+          content: [toolResult],
+          name: undefined,
+          role: vscode.LanguageModelChatMessageRole.User,
+        },
+      ];
+
+      const out = convertMessages(messages, "test.model-id");
+      const resultContent = out.messages[1].content?.[0]?.toolResult?.content?.[0] as {
+        text?: string;
+      };
+
+      assert.equal(resultContent.text, '{"result":"ok","values":[1,2,3]}');
+    });
+
     test("merges consecutive user messages", () => {
       const messages: vscode.LanguageModelChatMessage[] = [
         {
@@ -650,16 +715,16 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     test("logger supports all log levels", () => {
       const logs: { args: unknown[]; level: string }[] = [];
       const mockChannel = {
-        debug: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "debug" }),
-        error: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "error" }),
-        info: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "info" }),
-        trace: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "trace" }),
-        warn: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "warn" }),
+        debug: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "debug" }),
+        error: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "error" }),
+        info: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "info" }),
+        trace: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "trace" }),
+        warn: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "warn" }),
       } as unknown as vscode.LogOutputChannel;
 
       logger.initialize(mockChannel, vscode.ExtensionMode.Development);
@@ -686,16 +751,16 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     test("logger.log (deprecated) uses info level", () => {
       const logs: { args: unknown[]; level: string }[] = [];
       const mockChannel = {
-        debug: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "debug" }),
-        error: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "error" }),
-        info: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "info" }),
-        trace: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "trace" }),
-        warn: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "warn" }),
+        debug: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "debug" }),
+        error: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "error" }),
+        info: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "info" }),
+        trace: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "trace" }),
+        warn: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "warn" }),
       } as unknown as vscode.LogOutputChannel;
 
       logger.initialize(mockChannel, vscode.ExtensionMode.Production);
@@ -710,16 +775,16 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     test("logger passes structured data directly", () => {
       const logs: { args: unknown[]; level: string }[] = [];
       const mockChannel = {
-        debug: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "debug" }),
-        error: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "error" }),
-        info: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "info" }),
-        trace: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "trace" }),
-        warn: (msg: string, ...args: unknown[]) =>
-          logs.push({ args: [msg, ...args], level: "warn" }),
+        debug: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "debug" }),
+        error: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "error" }),
+        info: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "info" }),
+        trace: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "trace" }),
+        warn: (message: string, ...arguments_: unknown[]) =>
+          logs.push({ args: [message, ...arguments_], level: "warn" }),
       } as unknown as vscode.LogOutputChannel;
 
       logger.initialize(mockChannel, vscode.ExtensionMode.Development);
@@ -1243,13 +1308,13 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
   suite("buildConfigurationSchema", () => {
     test("returns undefined for models with no configurable options (Nova Lite)", () => {
       // Nova Lite: 300K context, 8192 output — no thinking, no reasoning, no 1M opt-in
-      const schema = callBuildConfigurationSchema("amazon.nova-lite-v1:0");
+      const schema = callBuildConfigSchema("amazon.nova-lite-v1:0");
       assert.equal(schema, undefined);
     });
 
     test("returns contextSize picker for Opus 4.6 (optional 1M context)", () => {
       // Opus 4.6 default: 200K context window (full, not context-output)
-      const schema = callBuildConfigurationSchema("anthropic.claude-opus-4-6-v1");
+      const schema = callBuildConfigSchema("anthropic.claude-opus-4-6-v1");
       assert.ok(schema?.properties?.contextSize, "should have contextSize property");
       const cs = schema.properties.contextSize;
       assert.deepEqual(cs.enum, [200_000, 1_000_000]);
@@ -1259,7 +1324,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("returns NO contextSize picker for Opus 4.7 (always 1M context)", () => {
       // Opus 4.7: 1M context is always-on — no picker needed
-      const schema = callBuildConfigurationSchema("anthropic.claude-opus-4-7-20260420-v1:0");
+      const schema = callBuildConfigSchema("anthropic.claude-opus-4-7-20260420-v1:0");
       assert.equal(
         schema?.properties?.contextSize,
         undefined,
@@ -1269,7 +1334,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("returns thinkingEffort picker for Sonnet 4.6 (supportsThinkingEffort)", () => {
       // Sonnet 4.6 default: 200K context window
-      const schema = callBuildConfigurationSchema("anthropic.claude-sonnet-4-6");
+      const schema = callBuildConfigSchema("anthropic.claude-sonnet-4-6");
       assert.ok(schema?.properties?.thinkingEffort, "should have thinkingEffort property");
       const te = schema.properties.thinkingEffort;
       assert.deepEqual(te.enum, ["low", "medium", "high"]);
@@ -1278,12 +1343,12 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     });
 
     test("returns NO thinkingEffort picker for Sonnet 3.7 (thinking but not effort)", () => {
-      const schema = callBuildConfigurationSchema("anthropic.claude-3-7-sonnet-20250219-v1:0");
+      const schema = callBuildConfigSchema("anthropic.claude-3-7-sonnet-20250219-v1:0");
       assert.equal(schema?.properties?.thinkingEffort, undefined);
     });
 
     test("returns reasoningEffort picker for DeepSeek V3.2 (supportsReasoningEffort)", () => {
-      const schema = callBuildConfigurationSchema("deepseek.deepseek-v3-2-20250615");
+      const schema = callBuildConfigSchema("deepseek.deepseek-v3-2-20250615");
       assert.ok(schema?.properties?.reasoningEffort, "should have reasoningEffort property");
       const re = schema.properties.reasoningEffort;
       assert.deepEqual(re.enum, ["low", "medium", "high"]);
@@ -1291,7 +1356,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     });
 
     test("includes minimal effort level for OpenAI gpt-oss", () => {
-      const schema = callBuildConfigurationSchema("openai.gpt-oss-20b");
+      const schema = callBuildConfigSchema("openai.gpt-oss-20b");
       assert.ok(schema?.properties?.reasoningEffort);
       assert.deepEqual(schema.properties.reasoningEffort.enum, [
         "minimal",
@@ -1303,7 +1368,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("Sonnet 4.6 has no contextSize picker (always-1M) but has thinkingEffort picker", () => {
       // Sonnet 4.6 is always-1M — no optional context extension, so no picker.
-      const schema = callBuildConfigurationSchema("anthropic.claude-sonnet-4-6");
+      const schema = callBuildConfigSchema("anthropic.claude-sonnet-4-6");
       assert.equal(schema?.properties?.contextSize, undefined, "should NOT have contextSize");
       assert.ok(schema?.properties?.thinkingEffort, "should have thinkingEffort");
       assert.equal(schema?.properties?.reasoningEffort, undefined);
@@ -1311,7 +1376,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("Sonnet 4.5 returns contextSize picker and thinkingEffort picker", () => {
       // Sonnet 4.5 has optional 1M via beta header, and supports extended thinking.
-      const schema = callBuildConfigurationSchema("anthropic.claude-sonnet-4-5-20250929-v1:0");
+      const schema = callBuildConfigSchema("anthropic.claude-sonnet-4-5-20250929-v1:0");
       assert.ok(schema?.properties?.contextSize, "should have contextSize");
       // Sonnet 4.5 supports thinking (supportsThinking) but not thinkingEffort
       // (effort control is only on Opus 4.5/4.6/4.8 and Sonnet 4.6)
@@ -1380,7 +1445,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     test("uses models.dev limits when available — Sonnet 4.6 is always-1M", () => {
       // models.dev says Sonnet 4.6 has 1M context / 64K output (always-on, no beta header).
       // context1M.enabled flag has no effect — 1M is the default.
-      const map = makeDevMapEntry("anthropic.claude-sonnet-4-6", 1_000_000, 64_000);
+      const map = makeDevelopmentMapEntry("anthropic.claude-sonnet-4-6", 1_000_000, 64_000);
       const withoutExtended = callResolveModelLimits("anthropic.claude-sonnet-4-6", false, map);
       assert.equal(withoutExtended.maxOutputTokens, 64_000);
       assert.equal(withoutExtended.maxInputTokens, 1_000_000 - 64_000); // always 1M - 64K
@@ -1392,7 +1457,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("uses models.dev limits — Sonnet 4.5 is optional-1M (capped at 200K when disabled)", () => {
       // Sonnet 4.5 has optional 1M via beta header.
-      const map = makeDevMapEntry("anthropic.claude-sonnet-4-5-20250929-v1:0", 1_000_000, 64_000);
+      const map = makeDevelopmentMapEntry("anthropic.claude-sonnet-4-5-20250929-v1:0", 1_000_000, 64_000);
       const withoutExtended = callResolveModelLimits(
         "anthropic.claude-sonnet-4-5-20250929-v1:0",
         false,
@@ -1413,7 +1478,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
     test("uses models.dev limits for always-1M models (Opus 4.7)", () => {
       // Opus 4.7 doesn't require beta header — 1M is always-on.
       // maxInputTokens = 1M - 128K (input budget; picker shows 1M total).
-      const map = makeDevMapEntry("anthropic.claude-opus-4-7", 1_000_000, 128_000);
+      const map = makeDevelopmentMapEntry("anthropic.claude-opus-4-7", 1_000_000, 128_000);
       const result = callResolveModelLimits("anthropic.claude-opus-4-7", false, map);
       assert.equal(result.maxOutputTokens, 128_000);
       assert.equal(result.maxInputTokens, 1_000_000 - 128_000); // input budget = 1M - 128K
@@ -1421,7 +1486,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("uses models.dev limits for non-Claude models (Nova Pro)", () => {
       // Nova Pro: 300K context window, 8192 output.
-      const map = makeDevMapEntry("amazon.nova-pro-v1:0", 300_000, 8192);
+      const map = makeDevelopmentMapEntry("amazon.nova-pro-v1:0", 300_000, 8192);
       const result = callResolveModelLimits("amazon.nova-pro-v1:0", false, map);
       assert.equal(result.maxOutputTokens, 8192);
       assert.equal(result.maxInputTokens, 300_000 - 8192); // input budget = 300K - 8K
@@ -1436,7 +1501,7 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
 
     test("strips regional prefix when looking up models.dev entry", () => {
       // models.dev has bare ID; model ID has regional prefix
-      const map = makeDevMapEntry("anthropic.claude-sonnet-4-6", 1_000_000, 64_000);
+      const map = makeDevelopmentMapEntry("anthropic.claude-sonnet-4-6", 1_000_000, 64_000);
       const result = callResolveModelLimits("us.anthropic.claude-sonnet-4-6", true, map);
       assert.equal(result.maxInputTokens, 1_000_000 - 64_000); // always 1M - 64K
     });
@@ -1445,25 +1510,25 @@ suite("Amazon Bedrock Chat Provider Extension", () => {
   suite("buildConfigurationSchema with models.dev data", () => {
     test("reasoningEffort picker appears for new non-Anthropic reasoning model via models.dev", () => {
       // Simulate a brand-new model not in profiles.ts but present in models.dev
-      const devMap: ModelsDevMap = new Map([
+      const developmentMap: ModelsDevelopmentMap = new Map([
         [
           "newprovider.new-reasoning-model",
           { limit: { context: 100_000, output: 8000 }, reasoning: true },
         ],
       ]);
-      const schema = callBuildConfigurationSchema("newprovider.new-reasoning-model", devMap);
+      const schema = callBuildConfigSchema("newprovider.new-reasoning-model", developmentMap);
       assert.ok(schema?.properties?.reasoningEffort);
     });
 
     test("reasoningEffort picker does NOT appear for Anthropic models via models.dev reasoning flag", () => {
       // Anthropic models use thinkingEffort, not reasoningEffort
-      const devMap: ModelsDevMap = new Map([
+      const developmentMap: ModelsDevelopmentMap = new Map([
         [
           "anthropic.claude-sonnet-4-6",
           { limit: { context: 1_000_000, output: 64_000 }, reasoning: true },
         ],
       ]);
-      const schema = callBuildConfigurationSchema("anthropic.claude-sonnet-4-6", devMap);
+      const schema = callBuildConfigSchema("anthropic.claude-sonnet-4-6", developmentMap);
       assert.equal(schema?.properties?.reasoningEffort, undefined);
     });
   });

--- a/vscode.d.ts
+++ b/vscode.d.ts
@@ -4895,13 +4895,13 @@ declare module 'vscode' {
 		 */
 		Color = 15,
 		/**
-		 * The `Reference` completion item kind.
-		 */
-		Reference = 17,
-		/**
 		 * The `File` completion item kind.
 		 */
 		File = 16,
+		/**
+		 * The `Reference` completion item kind.
+		 */
+		Reference = 17,
 		/**
 		 * The `Folder` completion item kind.
 		 */
@@ -18390,7 +18390,7 @@ declare module 'vscode' {
 		 * until the cancellation is requested on the `token`.
 		 *
 		 * @param request Request information for the test run.
-		 * @param cancellationToken Token that signals the used asked to abort the
+		 * @param token Token that signals the used asked to abort the
 		 * test run. If cancellation is requested on this token, all {@link TestRun}
 		 * instances associated with the request will be
 		 * automatically cancelled as well.


### PR DESCRIPTION
This PR makes three changes to the Bedrock Copilot Chat extension to improve robustness and performance. I noticed that Sonnet 5 was not supported, and some other models had significant lag while processing tool calls.  

The fixes focus was on : 
- support newes claude & GPT models
- identify bottlenecks &  improve performance

I've used supervised AI to make the changes (manually identify problem & suggest solution, let AI implement it).  Tests were updated by AI. 



**1. Enhanced Models Cache Script (update-models-cache.sh)**

-  Read from a temporary file instead of stdin, improving robustness
- Added try/except for JSON parsing failures
- Switched JSON output from minified (separators=(',', ':')) to prettified (indent=2) to improve DIFF readability
- Moved model count calculation into Python (clearer output messaging)
- Cleanup trap for temporary files
- Finally : added the updated cache (with sonnet 5, GPT Luna etc

_Benefits_: Easier code review of cache diffs, better error diagnostics, and more maintainable script flow.


**2. New Settings**

_bedrock.temperature.override:_ Global temperature parameter override for models with deprecated or broken temperature handling. Useful for working around models that incorrectly reject or require the temperature parameter.  Support for this setting was wired in the provider where needed. 

**2. Bedrock Client Improvements**
- Added inference profile discovery with regional/global preference support
- Added countTokensLocalEstimate() for fallback when API is unavailable
- Caching of unsupported CountTokens models to avoid repeated API attempts
- Local token estimation with model-aware multipliers: Sonnet (1.3x), Opus (1.1x), Haiku (1.0x), GPT-5 (0.95x)
- Skip redundant re-authentication: Check model accessibility before making redundant profile/auth calls
- Use local countToken estimation by default (single round-trip), fall back to API only when needed
- Enhanced model capability detection with thinking effort and adaptive thinking support
- Added support for newer models: Opus 4.7 (with effort headers), Sonnet 5, Haiku 4.5, GPT-4.6 
- Added model capability profiles for thinking, extended thinking, adaptive thinking


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global Bedrock setting to override automatic temperature handling.
  * Added support for newer Anthropic Sonnet capabilities, including extended context and output limits.
  * Improved compatibility detection for OpenAI reasoning and temperature settings.
* **Bug Fixes**
  * Requests now avoid incompatible parameters and retry when unsupported settings are reported.
  * Improved structured tool-result serialization and token estimation.
  * Improved model discovery and configuration updates.
* **Tests**
  * Expanded coverage for model limits, token estimation, and tool-result formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->